### PR TITLE
allow passing sRGB colors, e.g. from react-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,16 @@ ShopifyCheckoutKit.configure {
     // Force web theme, passing colors for the modal header and background
     it.colorScheme = ColorScheme.Web(
         Colors(
-            webViewBackground = R.color.web_view_background,
-            headerFont = R.color.header_font,
-            headerBackground = R.color.header_background,
-            spinnerColor = R.color.loading_spinner,
+            webViewBackground = Color.ResourceId(R.color.web_view_background),
+            headerFont = Color.ResourceId(R.color.header_font),
+            headerBackground = Color.ResourceId(R.color.header_background),
+            spinnerColor = Color.ResourceId(R.color.loading_spinner),
         )
     )
 }
 ```
+
+_Note: Colors can also be specified in sRGB format (e.g. `Color.SRGB(-0xff0001)`)_
 
 _Note: use preloading to optimize and deliver an instant buyer experience._
 

--- a/lib/src/main/java/com/shopify/checkoutkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/CheckoutDialog.kt
@@ -133,16 +133,16 @@ internal class CheckoutDialog(
     }
 
     private fun ColorScheme.headerBackgroundColor() =
-        getColor(context, this.headerBackgroundColor(context.isDarkTheme()))
+        this.headerBackgroundColor(context.isDarkTheme()).getValue(context)
 
     private fun ColorScheme.webViewBackgroundColor() =
-        getColor(context, this.webViewBackgroundColor(context.isDarkTheme()))
+        this.webViewBackgroundColor(context.isDarkTheme()).getValue(context)
 
     private fun ColorScheme.headerFontColor() =
-        getColor(context, this.headerFontColor(context.isDarkTheme()))
+        this.headerFontColor(context.isDarkTheme()).getValue(context)
 
     private fun ColorScheme.loadingSpinnerColor() =
-        getColor(context, this.loadingSpinnerColor(context.isDarkTheme()))
+        this.loadingSpinnerColor(context.isDarkTheme()).getValue(context)
 
     private fun Context.isDarkTheme() =
         resources.configuration.uiMode and UI_MODE_NIGHT_MASK == UI_MODE_NIGHT_YES

--- a/lib/src/main/java/com/shopify/checkoutkit/ColorScheme.kt
+++ b/lib/src/main/java/com/shopify/checkoutkit/ColorScheme.kt
@@ -22,6 +22,8 @@
  */
 package com.shopify.checkoutkit
 
+import android.content.Context
+import androidx.core.content.ContextCompat.getColor
 import kotlinx.serialization.Serializable
 
 /**
@@ -102,22 +104,35 @@ public sealed class ColorScheme(public val id: String) {
  */
 @Serializable
 public data class Colors(
-    val webViewBackground: Int,
-    val headerBackground: Int,
-    val headerFont: Int,
-    val spinnerColor: Int,
+    val webViewBackground: Color,
+    val headerBackground: Color,
+    val headerFont: Color,
+    val spinnerColor: Color,
 )
 
+@Serializable
+public sealed class Color {
+    @Serializable
+    public data class SRGB(public val sRGB: Int): Color()
+    @Serializable
+    public data class ResourceId(public val id: Int): Color()
+
+    public fun getValue(context: Context): Int = when (this) {
+        is ResourceId -> getColor(context, this.id)
+        is SRGB -> this.sRGB
+    }
+}
+
 private val defaultLightColors = Colors(
-    webViewBackground = R.color.checkoutLightBg,
-    headerBackground = R.color.checkoutLightBg,
-    headerFont = R.color.checkoutLightFont,
-    spinnerColor = R.color.checkoutLightLoadingSpinner,
+    webViewBackground = Color.ResourceId(R.color.checkoutLightBg),
+    headerBackground = Color.ResourceId(R.color.checkoutLightBg),
+    headerFont = Color.ResourceId(R.color.checkoutLightFont),
+    spinnerColor = Color.ResourceId(R.color.checkoutLightLoadingSpinner),
 )
 
 private val defaultDarkColors = Colors(
-    webViewBackground = R.color.checkoutDarkBg,
-    headerBackground = R.color.checkoutDarkBg,
-    headerFont = R.color.checkoutDarkFont,
-    spinnerColor = R.color.checkoutDarkLoadingSpinner,
+    webViewBackground = Color.ResourceId(R.color.checkoutDarkBg),
+    headerBackground = Color.ResourceId(R.color.checkoutDarkBg),
+    headerFont = Color.ResourceId(R.color.checkoutDarkFont),
+    spinnerColor = Color.ResourceId(R.color.checkoutDarkLoadingSpinner),
 )

--- a/lib/src/test/java/com/shopify/checkoutkit/CheckoutDialogTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/CheckoutDialogTest.kt
@@ -131,7 +131,7 @@ class CheckoutDialogTest {
         val dialog = ShadowDialog.getLatestDialog()
         val header = dialog.findViewById<Toolbar>(R.id.checkoutSdkHeader)
         val headerBackgroundColor = backgroundColor(header)
-        val configuredColor = activity.getColor(customColors.headerBackground)
+        val configuredColor = customColors.headerBackground.getValue(activity)
 
         assertThat(headerBackgroundColor).isEqualTo(configuredColor)
     }
@@ -146,7 +146,7 @@ class CheckoutDialogTest {
         val dialog = ShadowDialog.getLatestDialog()
         val webViewContainer = dialog.findViewById<FrameLayout>(R.id.checkoutSdkContainer)
         val webViewContainerBackgroundColor = backgroundColor(webViewContainer)
-        val configuredColor = activity.getColor(customColors.webViewBackground)
+        val configuredColor = customColors.webViewBackground.getValue(activity)
 
         assertThat(webViewContainerBackgroundColor).isEqualTo(configuredColor)
     }
@@ -157,10 +157,10 @@ class CheckoutDialogTest {
 
     private fun customColors(): Colors {
         return Colors(
-            headerFont = androidx.appcompat.R.color.material_grey_850,
-            headerBackground = androidx.appcompat.R.color.material_blue_grey_900,
-            webViewBackground = androidx.appcompat.R.color.material_deep_teal_200,
-            spinnerColor = androidx.appcompat.R.color.background_material_dark,
+            headerFont = Color.ResourceId(androidx.appcompat.R.color.material_grey_850),
+            headerBackground = Color.ResourceId(androidx.appcompat.R.color.material_blue_grey_900),
+            webViewBackground = Color.ResourceId(androidx.appcompat.R.color.material_deep_teal_200),
+            spinnerColor = Color.ResourceId(androidx.appcompat.R.color.background_material_dark),
         )
     }
 

--- a/lib/src/test/java/com/shopify/checkoutkit/ColorSchemeTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutkit/ColorSchemeTest.kt
@@ -32,156 +32,156 @@ class ColorSchemeTest {
     fun `dark color scheme has defaults matching idiomatic dark checkout`() {
         val dark = ColorScheme.Dark()
 
-        assertThat(dark.colors.headerBackground).isEqualTo(R.color.checkoutDarkBg)
-        assertThat(dark.colors.headerFont).isEqualTo(R.color.checkoutDarkFont)
-        assertThat(dark.colors.webViewBackground).isEqualTo(R.color.checkoutDarkBg)
-        assertThat(dark.colors.spinnerColor).isEqualTo(R.color.checkoutDarkLoadingSpinner)
+        assertThat(dark.colors.headerBackground).isEqualTo(Color.ResourceId(R.color.checkoutDarkBg))
+        assertThat(dark.colors.headerFont).isEqualTo(Color.ResourceId(R.color.checkoutDarkFont))
+        assertThat(dark.colors.webViewBackground).isEqualTo(Color.ResourceId(R.color.checkoutDarkBg))
+        assertThat(dark.colors.spinnerColor).isEqualTo(Color.ResourceId(R.color.checkoutDarkLoadingSpinner))
     }
 
     @Test
     fun `light color scheme has defaults matching idiomatic light checkout`() {
         val light = ColorScheme.Light()
 
-        assertThat(light.colors.headerBackground).isEqualTo(R.color.checkoutLightBg)
-        assertThat(light.colors.headerFont).isEqualTo(R.color.checkoutLightFont)
-        assertThat(light.colors.webViewBackground).isEqualTo(R.color.checkoutLightBg)
-        assertThat(light.colors.spinnerColor).isEqualTo(R.color.checkoutLightLoadingSpinner)
+        assertThat(light.colors.headerBackground).isEqualTo(Color.ResourceId(R.color.checkoutLightBg))
+        assertThat(light.colors.headerFont).isEqualTo(Color.ResourceId(R.color.checkoutLightFont))
+        assertThat(light.colors.webViewBackground).isEqualTo(Color.ResourceId(R.color.checkoutLightBg))
+        assertThat(light.colors.spinnerColor).isEqualTo(Color.ResourceId(R.color.checkoutLightLoadingSpinner))
     }
 
     @Test
     fun `automatic color scheme has defaults matching both idiomatic light and dark checkout`() {
         val automatic = ColorScheme.Automatic()
 
-        assertThat(automatic.darkColors.headerBackground).isEqualTo(R.color.checkoutDarkBg)
-        assertThat(automatic.darkColors.headerFont).isEqualTo(R.color.checkoutDarkFont)
-        assertThat(automatic.darkColors.webViewBackground).isEqualTo(R.color.checkoutDarkBg)
-        assertThat(automatic.darkColors.spinnerColor).isEqualTo(R.color.checkoutDarkLoadingSpinner)
+        assertThat(automatic.darkColors.headerBackground).isEqualTo(Color.ResourceId(R.color.checkoutDarkBg))
+        assertThat(automatic.darkColors.headerFont).isEqualTo(Color.ResourceId(R.color.checkoutDarkFont))
+        assertThat(automatic.darkColors.webViewBackground).isEqualTo(Color.ResourceId(R.color.checkoutDarkBg))
+        assertThat(automatic.darkColors.spinnerColor).isEqualTo(Color.ResourceId(R.color.checkoutDarkLoadingSpinner))
 
-        assertThat(automatic.lightColors.headerBackground).isEqualTo(R.color.checkoutLightBg)
-        assertThat(automatic.lightColors.headerFont).isEqualTo(R.color.checkoutLightFont)
-        assertThat(automatic.lightColors.webViewBackground).isEqualTo(R.color.checkoutLightBg)
-        assertThat(automatic.lightColors.spinnerColor).isEqualTo(R.color.checkoutLightLoadingSpinner)
+        assertThat(automatic.lightColors.headerBackground).isEqualTo(Color.ResourceId(R.color.checkoutLightBg))
+        assertThat(automatic.lightColors.headerFont).isEqualTo(Color.ResourceId(R.color.checkoutLightFont))
+        assertThat(automatic.lightColors.webViewBackground).isEqualTo(Color.ResourceId(R.color.checkoutLightBg))
+        assertThat(automatic.lightColors.spinnerColor).isEqualTo(Color.ResourceId(R.color.checkoutLightLoadingSpinner))
     }
 
     @Test
     fun `web color scheme has defaults matching idiomatic light checkout`() {
         val web = ColorScheme.Web()
 
-        assertThat(web.colors.headerBackground).isEqualTo(R.color.checkoutLightBg)
-        assertThat(web.colors.headerFont).isEqualTo(R.color.checkoutLightFont)
-        assertThat(web.colors.webViewBackground).isEqualTo(R.color.checkoutLightBg)
-        assertThat(web.colors.spinnerColor).isEqualTo(R.color.checkoutLightLoadingSpinner)
+        assertThat(web.colors.headerBackground).isEqualTo(Color.ResourceId(R.color.checkoutLightBg))
+        assertThat(web.colors.headerFont).isEqualTo(Color.ResourceId(R.color.checkoutLightFont))
+        assertThat(web.colors.webViewBackground).isEqualTo(Color.ResourceId(R.color.checkoutLightBg))
+        assertThat(web.colors.spinnerColor).isEqualTo(Color.ResourceId(R.color.checkoutLightLoadingSpinner))
     }
 
     @Test
     fun `color schemes defaults can be overridden`() {
         val web = ColorScheme.Web(
             Colors(
-                headerBackground = 1,
-                headerFont = 2,
-                webViewBackground = 3,
-                spinnerColor = 4,
+                headerBackground = Color.ResourceId(1),
+                headerFont = Color.ResourceId(2),
+                webViewBackground = Color.ResourceId(3),
+                spinnerColor = Color.ResourceId(4),
             )
         )
 
-        assertThat(web.colors.headerBackground).isEqualTo(1)
-        assertThat(web.colors.headerFont).isEqualTo(2)
-        assertThat(web.colors.webViewBackground).isEqualTo(3)
-        assertThat(web.colors.spinnerColor).isEqualTo(4)
+        assertThat(web.colors.headerBackground).isEqualTo(Color.ResourceId(1))
+        assertThat(web.colors.headerFont).isEqualTo(Color.ResourceId(2))
+        assertThat(web.colors.webViewBackground).isEqualTo(Color.ResourceId(3))
+        assertThat(web.colors.spinnerColor).isEqualTo(Color.ResourceId(4))
     }
 
     @Test
     fun `color schemes has a helper function for retrieving header background color`() {
         val automatic = ColorScheme.Automatic(
             lightColors = Colors(
-                headerBackground = 1,
-                headerFont = 2,
-                webViewBackground = 3,
-                spinnerColor = 4,
+                headerBackground = Color.ResourceId(1),
+                headerFont = Color.ResourceId(2),
+                webViewBackground = Color.ResourceId(3),
+                spinnerColor = Color.ResourceId(4),
             ),
             darkColors = Colors(
-                headerBackground = 5,
-                headerFont = 6,
-                webViewBackground = 7,
-                spinnerColor = 8,
+                headerBackground = Color.ResourceId(5),
+                headerFont = Color.ResourceId(6),
+                webViewBackground = Color.ResourceId(7),
+                spinnerColor = Color.ResourceId(8),
             )
         )
 
         assertThat(
             automatic.headerBackgroundColor(isDark = false)
-        ).isEqualTo(1)
+        ).isEqualTo(Color.ResourceId(1))
 
         assertThat(
             automatic.headerBackgroundColor(isDark = true)
-        ).isEqualTo(5)
+        ).isEqualTo(Color.ResourceId(5))
     }
 
     @Test
     fun `color schemes has a helper function for retrieving header font color`() {
         val automatic = ColorScheme.Automatic(
             lightColors = Colors(
-                headerBackground = 1,
-                headerFont = 2,
-                webViewBackground = 3,
-                spinnerColor = 4,
+                headerBackground = Color.ResourceId(1),
+                headerFont = Color.ResourceId(2),
+                webViewBackground = Color.ResourceId(3),
+                spinnerColor = Color.ResourceId(4),
             ),
             darkColors = Colors(
-                headerBackground = 5,
-                headerFont = 6,
-                webViewBackground = 7,
-                spinnerColor = 8
+                headerBackground = Color.ResourceId(5),
+                headerFont = Color.ResourceId(6),
+                webViewBackground = Color.ResourceId(7),
+                spinnerColor = Color.ResourceId(8),
             )
         )
 
         assertThat(
             automatic.headerFontColor(isDark = false)
-        ).isEqualTo(2)
+        ).isEqualTo(Color.ResourceId(2))
 
         assertThat(
             automatic.headerFontColor(isDark = true)
-        ).isEqualTo(6)
+        ).isEqualTo(Color.ResourceId(6))
     }
 
     @Test
     fun `color schemes has a helper function for retrieving webview background color`() {
         val automatic = ColorScheme.Automatic(
             lightColors = Colors(
-                headerBackground = 1,
-                headerFont = 2,
-                webViewBackground = 3,
-                spinnerColor = 4,
+                headerBackground = Color.ResourceId(1),
+                headerFont = Color.ResourceId(2),
+                webViewBackground = Color.ResourceId(3),
+                spinnerColor = Color.ResourceId(4),
             ),
             darkColors = Colors(
-                headerBackground = 5,
-                headerFont = 6,
-                webViewBackground = 7,
-                spinnerColor = 8,
+                headerBackground = Color.ResourceId(5),
+                headerFont = Color.ResourceId(6),
+                webViewBackground = Color.ResourceId(7),
+                spinnerColor = Color.ResourceId(8),
             )
         )
 
         assertThat(
             automatic.webViewBackgroundColor(isDark = false)
-        ).isEqualTo(3)
+        ).isEqualTo(Color.ResourceId(3))
 
         assertThat(
             automatic.webViewBackgroundColor(isDark = true)
-        ).isEqualTo(7)
+        ).isEqualTo(Color.ResourceId(7))
     }
 
     @Test
     fun `color scheme can be serialized`() {
         val automatic = ColorScheme.Automatic(
             lightColors = Colors(
-                headerBackground = 1,
-                headerFont = 2,
-                webViewBackground = 3,
-                spinnerColor = 4
+                headerBackground = Color.ResourceId(1),
+                headerFont = Color.ResourceId(2),
+                webViewBackground = Color.ResourceId(3),
+                spinnerColor = Color.ResourceId(4),
             ),
             darkColors = Colors(
-                headerBackground = 5,
-                headerFont = 6,
-                webViewBackground = 8,
-                spinnerColor = 9,
+                headerBackground = Color.ResourceId(5),
+                headerFont = Color.ResourceId(6),
+                webViewBackground = Color.ResourceId(8),
+                spinnerColor = Color.ResourceId(9),
             )
         )
 

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/settings/ColorSchemeSection.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/settings/ColorSchemeSection.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.sp
 import com.shopify.checkoutkit.ColorScheme
 import com.shopify.checkoutkit.Colors
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.R
+import com.shopify.checkoutkit.Color
 
 @Composable
 fun ColorSchemeSection(
@@ -109,10 +110,10 @@ fun ColorSchemeSection(
         ColorSchemeOption(
             colorScheme = ColorScheme.Web(
                 colors = Colors(
-                    headerBackground = R.color.header_bg,
-                    webViewBackground = R.color.web_view_bg,
-                    headerFont = R.color.header_font,
-                    spinnerColor = R.color.bright_spinner,
+                    headerBackground = Color.ResourceId(R.color.header_bg),
+                    webViewBackground = Color.ResourceId(R.color.web_view_bg),
+                    headerFont = Color.ResourceId(R.color.header_font),
+                    spinnerColor = Color.ResourceId(R.color.bright_spinner),
                 )
             ),
             description = "Applies a color scheme in checkout based on the current checkout web configuration",

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/settings/PreferencesManager.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/settings/PreferencesManager.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
 
-val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "checkoutSdkSettings")
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "checkoutKitSettings")
 
 class PreferencesManager(private val context: Context) {
     private val decoder: Json = Json { ignoreUnknownKeys = true }


### PR DESCRIPTION
### What are you trying to accomplish?

Allow sRGB colors to be set in ColorSchemes, partially to make the integration with react-native easier.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with
  the [contributing documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with
  the [code of conduct documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](https://github.com/Shopify/checkout-kit-android/blob/main/README.md) (if applicable).
