### PR TITLE
add content description to sample nav icon buttons

### DIFF
--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/BottomAppBarWithNavigation.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/BottomAppBarWithNavigation.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.R
@@ -104,7 +106,10 @@ fun NavigationItem(
     badge: @Composable () -> Unit = {}
 ) {
     IconButton(
-        onClick = { navController.navigate(screen.route) }
+        onClick = { navController.navigate(screen.route) },
+        modifier = Modifier.semantics {
+            this.contentDescription = "$label icon"
+        }
     ) {
         val tint = if (currentScreen == screen) {
             MaterialTheme.colors.primary


### PR DESCRIPTION
### What are you trying to accomplish?

Small tweak to add a content description to the icon buttons in the sample app. This also makes them more easy to target via test automation

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with
  the [contributing documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with
  the [code of conduct documentation](https://github.com/Shopify/checkout-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-kit-android/blob/main/README.md) (if applicable).
