### PR TITLE
set buyer identity country code to match test store

### DIFF
--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/CartViewModel.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/CartViewModel.kt
@@ -89,7 +89,12 @@ class CartViewModel(
     }
 
     private fun performCartCreate(variant: ID, onComplete: OnComplete) {
-        val buyerIdentity = if (demoBuyerIdentityEnabled) DemoBuyerIdentity.value else null
+        val buyerIdentity = if (demoBuyerIdentityEnabled) {
+            DemoBuyerIdentity.value
+        } else {
+            Storefront.CartBuyerIdentityInput().setCountryCode(Storefront.CountryCode.CA)
+        }
+
         client.createCart(
             variant = Storefront.ProductVariant(variant),
             buyerIdentity = buyerIdentity,


### PR DESCRIPTION
### What are you trying to accomplish?

Set default buyer identity country code to match test store and the demo user's country code

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
