### PR TITLE
prevent dismissing the loading spinner on a redirect

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -43,8 +43,6 @@ import android.widget.ProgressBar
 import androidx.activity.ComponentActivity
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.Toolbar
-import androidx.core.content.ContextCompat.getColor
-import androidx.core.view.children
 
 internal class CheckoutDialog(
     private val checkoutUrl: String,

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -74,6 +74,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
     }
 
     private var initLoadTime: Long = -1
+    private var cartUrl: String = ""
 
     init {
         configureWebView()
@@ -124,6 +125,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
 
     fun loadCheckout(url: String) {
         initLoadTime = System.currentTimeMillis()
+        cartUrl = url
         Handler(Looper.getMainLooper()).post {
             loadUrl(url)
         }
@@ -138,7 +140,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
 
         override fun onPageFinished(view: WebView, url: String) {
             super.onPageFinished(view, url)
-            if (view.contentHeight == 0) return
+            if (url == cartUrl) return
 
             loadComplete = true
             val timeToLoad = System.currentTimeMillis() - initLoadTime

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -138,6 +138,8 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
 
         override fun onPageFinished(view: WebView, url: String) {
             super.onPageFinished(view, url)
+            if (view.contentHeight == 0) return
+
             loadComplete = true
             val timeToLoad = System.currentTimeMillis() - initLoadTime
             checkoutBridge.sendMessage(view, CheckoutBridge.SDKOperation.Instrumentation(

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
@@ -141,23 +141,23 @@ class CheckoutWebViewClientTest {
     }
 
     @Test
-    fun `onPageFinished does not call delegate if view content is empty (for example, a redirect)`() {
+    fun `onPageFinished does not call delegate if the page that has finished loading is the intial cart URL`() {
         val view = spy(viewWithProcessor(activity))
-        doReturn(0).whenever(view).contentHeight
+        view.loadCheckout("https://cart")
 
         val webViewClient = view.CheckoutWebViewClient()
-        webViewClient.onPageFinished(view, "https://anything")
+        webViewClient.onPageFinished(view, "https://cart")
 
         verify(checkoutWebViewEventProcessor, never()).onCheckoutViewLoadComplete()
     }
 
     @Test
-    fun `onPageFinished calls delegate to remove loading spinner if view content not empty`() {
+    fun `onPageFinished calls delegate to remove loading spinner if the page that has finished loading is any other page`() {
         val view = spy(viewWithProcessor(activity))
-        doReturn(1).whenever(view).contentHeight
+        view.loadCheckout("https://cart")
 
         val webViewClient = view.CheckoutWebViewClient()
-        webViewClient.onPageFinished(view, "https://anything")
+        webViewClient.onPageFinished(view, "https://checkout")
 
         verify(checkoutWebViewEventProcessor).onCheckoutViewLoadComplete()
     }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
@@ -33,6 +33,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
@@ -140,10 +141,22 @@ class CheckoutWebViewClientTest {
     }
 
     @Test
-    fun `onPageFinished calls delegate to remove loading spinner`() {
-        val view = viewWithProcessor(activity)
-        val webViewClient = view.CheckoutWebViewClient()
+    fun `onPageFinished does not call delegate if view content is empty (for example, a redirect)`() {
+        val view = spy(viewWithProcessor(activity))
+        doReturn(0).whenever(view).contentHeight
 
+        val webViewClient = view.CheckoutWebViewClient()
+        webViewClient.onPageFinished(view, "https://anything")
+
+        verify(checkoutWebViewEventProcessor, never()).onCheckoutViewLoadComplete()
+    }
+
+    @Test
+    fun `onPageFinished calls delegate to remove loading spinner if view content not empty`() {
+        val view = spy(viewWithProcessor(activity))
+        doReturn(1).whenever(view).contentHeight
+
+        val webViewClient = view.CheckoutWebViewClient()
         webViewClient.onPageFinished(view, "https://anything")
 
         verify(checkoutWebViewEventProcessor).onCheckoutViewLoadComplete()

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -33,10 +33,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.contains
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
@@ -97,12 +95,9 @@ class CheckoutWebViewTest {
         val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
 
         val shadow = shadowOf(view)
-        var spy = spy(view)
-        doReturn(1).whenever(spy).contentHeight
+        shadow.webViewClient.onPageFinished(view, "https://anything")
 
-        shadow.webViewClient.onPageFinished(spy, "https://anything")
-
-        spy = spy(view)
+        val spy = spy(view)
         spy.notifyPresented()
 
         verify(spy).evaluateJavascript(

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -33,10 +33,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.contains
 import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.spy
-import org.mockito.Mockito.timeout
-import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
@@ -97,9 +97,12 @@ class CheckoutWebViewTest {
         val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
 
         val shadow = shadowOf(view)
-        shadow.webViewClient.onPageFinished(view, "https://anything")
+        var spy = spy(view)
+        doReturn(1).whenever(spy).contentHeight
 
-        val spy = spy(view)
+        shadow.webViewClient.onPageFinished(spy, "https://anything")
+
+        spy = spy(view)
         spy.notifyPresented()
 
         verify(spy).evaluateJavascript(


### PR DESCRIPTION
### What are you trying to accomplish?

`onPageFinished` is being invoked twice on a normal guest flow, the first appears to be the cart redirect. This is causing us to dismiss the loading spinner too early, and send an instrumentation message twice:

https://github.com/Shopify/checkout-sheet-kit-android/assets/15106863/0f46c29e-011c-41fe-baab-158648cf71f9

URLs:
- `https://shop1.shopify.checkout-web-fvy7.daniel-kift.eu.spin.dev/cart/c/c1-cee737be76e498a6eefa107843517818?key=0f92b50b0375b1c8224d0950e0bb5210`
- `https://shop1.shopify.checkout-web-fvy7.daniel-kift.eu.spin.dev/checkouts/cn/c1-cee737be76e498a6eefa107843517818?locale=en-CA&skip_shop_pay=prompt_allowed`

This PR adds a condition, that we should not set loadComplete to true for `onPageFinished` calls if the content height of the view is 0.

https://github.com/Shopify/checkout-sheet-kit-android/assets/15106863/9265e005-6467-45b2-b7b6-7b2e4adff2c8

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
