### PR TITLE
match header horizontal padding with checkout

### DIFF
--- a/lib/src/main/res/layout/dialog_checkout.xml
+++ b/lib/src/main/res/layout/dialog_checkout.xml
@@ -8,6 +8,8 @@
         android:id="@+id/checkoutSdkHeader"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:contentInsetStart="22dp"
+        android:paddingEnd="4dp"
         android:minHeight="?attr/actionBarSize"
         app:title="@string/checkout_web_view_title"
         android:theme="@style/Theme.AppCompat.DayNight"


### PR DESCRIPTION
### What are you trying to accomplish?

Update the header horizontal whitespace to match those in checkout

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
