### PR TITLE
Rename analytics event to Web Pixels event

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutBridge.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutBridge.kt
@@ -25,7 +25,7 @@ package com.shopify.checkoutsheetkit
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 
-import com.shopify.checkoutsheetkit.CheckoutBridge.CheckoutWebOperation.ANALYTICS
+import com.shopify.checkoutsheetkit.CheckoutBridge.CheckoutWebOperation.WEB_PIXELS
 import com.shopify.checkoutsheetkit.CheckoutBridge.CheckoutWebOperation.COMPLETED
 import com.shopify.checkoutsheetkit.CheckoutBridge.CheckoutWebOperation.MODAL
 import com.shopify.checkoutsheetkit.pixelevents.PixelEventDecoder
@@ -49,7 +49,7 @@ internal class CheckoutBridge(
     enum class CheckoutWebOperation(val key: String) {
         COMPLETED("completed"),
         MODAL("checkoutBlockingEvent"),
-        ANALYTICS("analytics");
+        WEB_PIXELS("webPixels");
 
         companion object {
             fun fromKey(key: String): CheckoutWebOperation? {
@@ -76,7 +76,7 @@ internal class CheckoutBridge(
                     eventProcessor.onCheckoutViewModalToggled(modalVisible)
                 }
             }
-            ANALYTICS -> {
+            WEB_PIXELS -> {
                 pixelEventDecoder.decode(decodedMsg)?.let { event ->
                     eventProcessor.onWebPixelEvent(event)
                 }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutBridgeTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutBridgeTest.kt
@@ -179,10 +179,10 @@ class CheckoutBridgeTest {
     }
 
     @Test
-    fun `calls onPixelEvent when valid analytics event received`() {
+    fun `calls onPixelEvent when valid webPixels event received`() {
         val eventString = """|
             |{
-            |   "name":"analytics",
+            |   "name":"webPixels",
             |   "body": "{
             |       \"name\": \"checkout_started\",
             |       \"event\": {

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/InteropTest.java
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/InteropTest.java
@@ -79,7 +79,7 @@ public class InteropTest {
             "}" +
         "}";
 
-        WebToSdkEvent webEvent = new WebToSdkEvent("analytics", eventString);
+        WebToSdkEvent webEvent = new WebToSdkEvent("webPixels", eventString);
         Json json = Json.Default;
 
         PixelEventDecoder decoder = new PixelEventDecoder(

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoderTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoderTest.kt
@@ -297,7 +297,7 @@ class PixelEventDecoderTest {
 
 private fun String.toWebToSdkEvent(): WebToSdkEvent {
     return WebToSdkEvent(
-        name = "analytics",
+        name = "webPixels",
         body = this,
     )
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Use a more specific name for the SDK analytics event.

### Before you deploy

- [ ] I have added tests to support my implementation
- [ ] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [ ] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
