### PR TITLE
loadCheckout is called in the cache, remove second call from preload()

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -43,8 +43,6 @@ import android.widget.ProgressBar
 import androidx.activity.ComponentActivity
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.Toolbar
-import androidx.core.content.ContextCompat.getColor
-import androidx.core.view.children
 
 internal class CheckoutDialog(
     private val checkoutUrl: String,

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
@@ -83,8 +83,7 @@ public object ShopifyCheckoutSheetKit {
     public fun preload(checkoutUrl: String, context: ComponentActivity) {
         if (!configuration.preloading.enabled) return
         CheckoutWebView.clearCache()
-        val checkoutWebView = CheckoutWebView.cacheableCheckoutView(checkoutUrl, context)
-        checkoutWebView.loadCheckout(checkoutUrl)
+        CheckoutWebView.cacheableCheckoutView(checkoutUrl, context)
     }
 
     /**

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -34,8 +34,6 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.contains
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.spy
-import org.mockito.Mockito.timeout
-import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner


### PR DESCRIPTION
### What are you trying to accomplish?

As we call `loadCheckout()` within the cache, `CheckoutWebView.cacheableCheckoutView()`, we shouldn't also call it explicitly within the `preload()` function.

This is causing unexpected behaviour with `onPageFinished()` for preloaded checkouts, and causing the loading spinner to be dismissed too early.

https://github.com/Shopify/checkout-sheet-kit-android/assets/15106863/470c2016-2a67-45f1-931d-ad577a005810

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
