### PR TITLE
simplify pixel types

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEvent.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEvent.kt
@@ -79,31 +79,20 @@ public sealed interface PixelEvent {
     public val type: EventType?
 }
 
-public interface StandardPixelEvent: PixelEvent {
-    public val data: StandardPixelEventData?
-}
+@Serializable
+public data class StandardPixelEvent(
+    public override val id: String? = null,
+    public override val name: String? = null,
+    public override val timestamp: String? = null,
+    public override val type: EventType? = null,
+    public val context: Context? = null,
+    public val data: StandardPixelEventData? = null,
+): PixelEvent
 
 @Serializable
 public data class StandardPixelEventData(
     public val checkout: Checkout? = null
 )
-
-public enum class StandardPixelsEventType(public val eventName: String) {
-    CHECKOUT_ADDRESS_INFO_SUBMITTED("checkout_address_info_submitted"),
-    CHECKOUT_COMPLETED("checkout_completed"),
-    CHECKOUT_CONTACT_INFO_SUBMITTED("checkout_contact_info_submitted"),
-    CHECKOUT_SHIPPING_INFO_SUBMITTED("checkout_shipping_info_submitted"),
-    CHECKOUT_STARTED("checkout_started"),
-    PAGE_VIEWED("page_viewed"),
-    PAYMENT_INFO_SUBMITTED("payment_info_submitted");
-
-    public companion object {
-        public fun fromEventName(eventName: String): StandardPixelsEventType? =
-            StandardPixelsEventType.values().firstOrNull {
-                it.eventName == eventName
-            }
-    }
-}
 
 /**
  * A snapshot of various read-only properties of the browser at the time of
@@ -502,21 +491,6 @@ public data class Product(
 )
 
 /**
- * The `checkout_address_info_submitted` event logs an instance of a customer
- * submitting their mailing address. This event is only available in checkouts
- * where checkout extensibility for customizations is enabled
- */
-@Serializable
-public data class CheckoutAddressInfoSubmittedEvent(
-    public override val id: String? = null,
-    public override val name: String? = null,
-    public override val timestamp: String? = null,
-    public override val type: EventType? = null,
-    public override val data: StandardPixelEventData? = null,
-    public val context: Context? = null,
-): StandardPixelEvent
-
-/**
  * A container for all the information required to add items to checkout and
  * pay.
  */
@@ -857,117 +831,6 @@ public data class Transaction(
      */
     public val gateway: String? = null
 )
-
-/**
- * The `checkout_completed` event logs when a visitor completes a purchase. This
- * event is available on the order status and checkout pages
- *
- * The `checkout_completed` event logs when a visitor completes a purchase.
- * This event is available on the order status and checkout pages
- */
-@Serializable
-public data class CheckoutCompletedEvent(
-    public override val id: String? = null,
-    public override val name: String? = null,
-    public override val timestamp: String? = null,
-    public override val type: EventType? = null,
-    public override val data: StandardPixelEventData? = null,
-    public val context: Context? = null,
-): StandardPixelEvent
-
-/**
- * The `checkout_contact_info_submitted` event logs an instance where a customer
- * submits a checkout form. This event is only available in checkouts where
- * checkout extensibility for customizations is enabled
- *
- * The `checkout_contact_info_submitted` event logs an instance where a
- * customer submits a checkout form. This event is only available in checkouts
- * where checkout extensibility for customizations is enabled
- */
-@Serializable
-public data class CheckoutContactInfoSubmittedEvent(
-    public override val id: String? = null,
-    public override val name: String? = null,
-    public override val timestamp: String? = null,
-    public override val type: EventType? = null,
-    public override val data: StandardPixelEventData? = null,
-    public val context: Context? = null,
-): StandardPixelEvent
-
-/**
- * The `checkout_shipping_info_submitted` event logs an instance where the
- * customer chooses a shipping rate. This event is only available in checkouts
- * where checkout extensibility for customizations is enabled
- */
-@Serializable
-public data class CheckoutShippingInfoSubmittedEvent(
-    public override val id: String? = null,
-    public override val name: String? = null,
-    public override val timestamp: String? = null,
-    public override val type: EventType? = null,
-    public val context: Context? = null,
-    public override val data: StandardPixelEventData? = null,
-): StandardPixelEvent
-
-/**
- * The `checkout_started` event logs an instance of a customer starting the
- * checkout process. This event is available on the checkout page. For checkout
- * extensibility, this event is triggered every time a customer enters checkout.
- * For non-checkout extensible shops, this event is only triggered the first
- * time a customer enters checkout.
- *
- * The `checkout_started` event logs an instance of a customer starting
- * the checkout process. This event is available on the checkout page. For
- * checkout extensibility, this event is triggered every time a customer
- * enters checkout. For non-checkout extensible shops, this event is only
- * triggered the first time a customer enters checkout.
- */
-@Serializable
-public data class CheckoutStartedEvent(
-    public override val id: String? = null,
-    public override val name: String? = null,
-    public override val timestamp: String? = null,
-    public override val type: EventType? = null,
-    public override val data: StandardPixelEventData? = null,
-    public val context: Context? = null,
-): StandardPixelEvent
-
-/**
- * The `page_viewed` event logs an instance where a customer visited a page.
- * This event is available on the online store, checkout, and order status pages
- *
- * The `page_viewed` event logs an instance where a customer visited a page.
- * This event is available on the online store, checkout, and order status
- * pages
- */
-@Serializable
-public data class PageViewedEvent(
-    public override val id: String? = null,
-    public override val name: String? = null,
-    public override val timestamp: String? = null,
-    public override val type: EventType? = null,
-    // Data will be null for this event, page viewed can be obtained via the context attribute
-    public override val data: StandardPixelEventData? = null,
-    public val context: Context? = null,
-): StandardPixelEvent
-
-/**
- * The `payment_info_submitted` event logs an instance of a customer submitting
- * their payment information. This event is available on the checkout page
- *
- * The `payment_info_submitted` event logs an instance of a customer
- * submitting their payment information. This event is available on the
- * checkout page
- */
-@Serializable
-public data class PaymentInfoSubmittedEvent(
-    public override val id: String? = null,
-    public override val name: String? = null,
-    public override val timestamp: String? = null,
-    public override val type: EventType? = null,
-    public override val data: StandardPixelEventData? = null,
-    public val context: Context? = null,
-): StandardPixelEvent
 
 /**
  * This event represents any custom events emitted by partners or merchants via

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEvent.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEvent.kt
@@ -84,9 +84,9 @@ public interface StandardPixelEvent: PixelEvent {
 }
 
 @Serializable
-public class StandardPixelEventData {
+public data class StandardPixelEventData(
     public val checkout: Checkout? = null
-}
+)
 
 public enum class StandardPixelsEventType(public val eventName: String) {
     CHECKOUT_ADDRESS_INFO_SUBMITTED("checkout_address_info_submitted"),

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEvent.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEvent.kt
@@ -79,6 +79,15 @@ public sealed interface PixelEvent {
     public val type: EventType?
 }
 
+public interface StandardPixelEvent: PixelEvent {
+    public val data: StandardPixelEventData?
+}
+
+@Serializable
+public class StandardPixelEventData {
+    public val checkout: Checkout? = null
+}
+
 public enum class StandardPixelsEventType(public val eventName: String) {
     CHECKOUT_ADDRESS_INFO_SUBMITTED("checkout_address_info_submitted"),
     CHECKOUT_COMPLETED("checkout_completed"),
@@ -503,14 +512,9 @@ public data class CheckoutAddressInfoSubmittedEvent(
     public override val name: String? = null,
     public override val timestamp: String? = null,
     public override val type: EventType? = null,
+    public override val data: StandardPixelEventData? = null,
     public val context: Context? = null,
-    public val data: CheckoutAddressInfoSubmittedData? = null,
-): PixelEvent
-
-@Serializable
-public data class CheckoutAddressInfoSubmittedData(
-    public val checkout: Checkout? = null
-)
+): StandardPixelEvent
 
 /**
  * A container for all the information required to add items to checkout and
@@ -867,14 +871,9 @@ public data class CheckoutCompletedEvent(
     public override val name: String? = null,
     public override val timestamp: String? = null,
     public override val type: EventType? = null,
+    public override val data: StandardPixelEventData? = null,
     public val context: Context? = null,
-    public val data: CheckoutCompletedData? = null,
-): PixelEvent
-
-@Serializable
-public data class CheckoutCompletedData(
-    public val checkout: Checkout? = null
-)
+): StandardPixelEvent
 
 /**
  * The `checkout_contact_info_submitted` event logs an instance where a customer
@@ -891,14 +890,9 @@ public data class CheckoutContactInfoSubmittedEvent(
     public override val name: String? = null,
     public override val timestamp: String? = null,
     public override val type: EventType? = null,
+    public override val data: StandardPixelEventData? = null,
     public val context: Context? = null,
-    public val data: CheckoutContactInfoSubmittedData? = null,
-): PixelEvent
-
-@Serializable
-public data class CheckoutContactInfoSubmittedData(
-    public val checkout: Checkout? = null
-)
+): StandardPixelEvent
 
 /**
  * The `checkout_shipping_info_submitted` event logs an instance where the
@@ -912,13 +906,8 @@ public data class CheckoutShippingInfoSubmittedEvent(
     public override val timestamp: String? = null,
     public override val type: EventType? = null,
     public val context: Context? = null,
-    public val data: CheckoutShippingInfoSubmittedData? = null,
-): PixelEvent
-
-@Serializable
-public data class CheckoutShippingInfoSubmittedData(
-    public val checkout: Checkout? = null
-)
+    public override val data: StandardPixelEventData? = null,
+): StandardPixelEvent
 
 /**
  * The `checkout_started` event logs an instance of a customer starting the
@@ -939,14 +928,9 @@ public data class CheckoutStartedEvent(
     public override val name: String? = null,
     public override val timestamp: String? = null,
     public override val type: EventType? = null,
+    public override val data: StandardPixelEventData? = null,
     public val context: Context? = null,
-    public val data: CheckoutStartedData? = null,
-): PixelEvent
-
-@Serializable
-public data class CheckoutStartedData(
-    public val checkout: Checkout? = null
-)
+): StandardPixelEvent
 
 /**
  * The `page_viewed` event logs an instance where a customer visited a page.
@@ -962,12 +946,10 @@ public data class PageViewedEvent(
     public override val name: String? = null,
     public override val timestamp: String? = null,
     public override val type: EventType? = null,
+    // Data will be null for this event, page viewed can be obtained via the context attribute
+    public override val data: StandardPixelEventData? = null,
     public val context: Context? = null,
-    public val data: PageViewedData? = null,
-): PixelEvent
-
-// The page viewed can be obtained via the context attribute
-public typealias PageViewedData = Unit
+): StandardPixelEvent
 
 /**
  * The `payment_info_submitted` event logs an instance of a customer submitting
@@ -983,21 +965,16 @@ public data class PaymentInfoSubmittedEvent(
     public override val name: String? = null,
     public override val timestamp: String? = null,
     public override val type: EventType? = null,
+    public override val data: StandardPixelEventData? = null,
     public val context: Context? = null,
-    public val data: PaymentInfoSubmittedData? = null,
-): PixelEvent
-
-@Serializable
-public data class PaymentInfoSubmittedData(
-    public val checkout: Checkout? = null
-)
+): StandardPixelEvent
 
 /**
  * This event represents any custom events emitted by partners or merchants via
  * the `publish` method
  */
 @Serializable
-public data class CustomEvent(
+public data class CustomPixelEvent(
     public override val id: String? = null,
     public override val name: String? = null,
     public override val timestamp: String? = null,

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoder.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoder.kt
@@ -70,7 +70,7 @@ internal class PixelEventDecoder @JvmOverloads constructor(
         }
     }
 
-    private fun decodeCustomEvent(jsonElement: JsonElement): CustomEvent {
-        return decoder.decodeFromJsonElement<CustomEvent>(jsonElement)
+    private fun decodeCustomEvent(jsonElement: JsonElement): CustomPixelEvent {
+        return decoder.decodeFromJsonElement<CustomPixelEvent>(jsonElement)
     }
 }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoder.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoder.kt
@@ -37,40 +37,13 @@ internal class PixelEventDecoder @JvmOverloads constructor(
         return try {
             val eventWrapper = decoder.decodeFromString<PixelEventWrapper>(decodedMsg.body)
             when (EventType.fromTypeName(eventWrapper.event["type"]?.jsonPrimitive?.content)) {
-                EventType.STANDARD -> decodeStandardEvent(eventWrapper.name, eventWrapper.event)
-                EventType.CUSTOM -> decodeCustomEvent(eventWrapper.event)
+                EventType.STANDARD -> decoder.decodeFromJsonElement<StandardPixelEvent>(eventWrapper.event)
+                EventType.CUSTOM -> decoder.decodeFromJsonElement<CustomPixelEvent>(eventWrapper.event)
                 else -> return null
             }
         } catch (e: Exception) {
             log.e("CheckoutBridge", "Failed to decode pixel event", e)
             null
         }
-    }
-
-    private fun decodeStandardEvent(name: String, jsonElement: JsonElement): PixelEvent? {
-        return when (StandardPixelsEventType.fromEventName(name)) {
-            StandardPixelsEventType.CHECKOUT_ADDRESS_INFO_SUBMITTED ->
-                decoder.decodeFromJsonElement<CheckoutAddressInfoSubmittedEvent>(jsonElement)
-            StandardPixelsEventType.CHECKOUT_COMPLETED ->
-                decoder.decodeFromJsonElement<CheckoutCompletedEvent>(jsonElement)
-            StandardPixelsEventType.CHECKOUT_CONTACT_INFO_SUBMITTED ->
-                decoder.decodeFromJsonElement<CheckoutContactInfoSubmittedEvent>(jsonElement)
-            StandardPixelsEventType.CHECKOUT_SHIPPING_INFO_SUBMITTED ->
-                decoder.decodeFromJsonElement<CheckoutShippingInfoSubmittedEvent>(jsonElement)
-            StandardPixelsEventType.CHECKOUT_STARTED ->
-                decoder.decodeFromJsonElement<CheckoutStartedEvent>(jsonElement)
-            StandardPixelsEventType.PAGE_VIEWED ->
-                decoder.decodeFromJsonElement<PageViewedEvent>(jsonElement)
-            StandardPixelsEventType.PAYMENT_INFO_SUBMITTED ->
-                decoder.decodeFromJsonElement<PaymentInfoSubmittedEvent>(jsonElement)
-            null -> {
-                log.w("CheckoutBridge", "Unrecognized standard pixel event received '$name'")
-                return null
-            }
-        }
-    }
-
-    private fun decodeCustomEvent(jsonElement: JsonElement): CustomPixelEvent {
-        return decoder.decodeFromJsonElement<CustomPixelEvent>(jsonElement)
     }
 }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoder.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoder.kt
@@ -25,7 +25,6 @@ package com.shopify.checkoutsheetkit.pixelevents
 import com.shopify.checkoutsheetkit.LogWrapper
 import com.shopify.checkoutsheetkit.WebToSdkEvent
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
 

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutBridgeTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutBridgeTest.kt
@@ -25,8 +25,8 @@ package com.shopify.checkoutsheetkit
 import android.webkit.WebView
 import com.shopify.checkoutsheetkit.CheckoutBridge.CheckoutWebOperation.COMPLETED
 import com.shopify.checkoutsheetkit.CheckoutBridge.CheckoutWebOperation.MODAL
-import com.shopify.checkoutsheetkit.pixelevents.CheckoutStartedEvent
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent
+import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEvent
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
@@ -208,6 +208,6 @@ class CheckoutBridgeTest {
         val captor = argumentCaptor<PixelEvent>()
         verify(mockEventProcessor, timeout(2000).times(1)).onWebPixelEvent(captor.capture())
 
-        assertThat(captor.firstValue).isInstanceOf(CheckoutStartedEvent::class.java)
+        assertThat(captor.firstValue).isInstanceOf(StandardPixelEvent::class.java)
     }
 }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/InteropTest.java
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/InteropTest.java
@@ -7,10 +7,10 @@ import android.app.Activity;
 import androidx.activity.ComponentActivity;
 import androidx.annotation.NonNull;
 
-import com.shopify.checkoutsheetkit.pixelevents.CheckoutStartedData;
 import com.shopify.checkoutsheetkit.pixelevents.CheckoutStartedEvent;
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent;
 import com.shopify.checkoutsheetkit.pixelevents.PixelEventDecoder;
+import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEventData;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -90,7 +90,7 @@ public class InteropTest {
 
         assertThat(event).isInstanceOf(CheckoutStartedEvent.class);
         CheckoutStartedEvent checkoutStartedEvent = (CheckoutStartedEvent) event;
-        CheckoutStartedData checkoutStartedData = checkoutStartedEvent.getData();
+        StandardPixelEventData checkoutStartedData = checkoutStartedEvent.getData();
         String checkoutStartedOrderId = checkoutStartedData.getCheckout().getOrder().getId();
 
         assertThat(checkoutStartedOrderId).isEqualTo(orderId);

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/InteropTest.java
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/InteropTest.java
@@ -7,9 +7,9 @@ import android.app.Activity;
 import androidx.activity.ComponentActivity;
 import androidx.annotation.NonNull;
 
-import com.shopify.checkoutsheetkit.pixelevents.CheckoutStartedEvent;
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent;
 import com.shopify.checkoutsheetkit.pixelevents.PixelEventDecoder;
+import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEvent;
 import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEventData;
 
 import org.junit.Before;
@@ -88,8 +88,8 @@ public class InteropTest {
 
         PixelEvent event = decoder.decode(webEvent);
 
-        assertThat(event).isInstanceOf(CheckoutStartedEvent.class);
-        CheckoutStartedEvent checkoutStartedEvent = (CheckoutStartedEvent) event;
+        assertThat(event).isInstanceOf(StandardPixelEvent.class);
+        StandardPixelEvent checkoutStartedEvent = (StandardPixelEvent) event;
         StandardPixelEventData checkoutStartedData = checkoutStartedEvent.getData();
         String checkoutStartedOrderId = checkoutStartedData.getCheckout().getOrder().getId();
 

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoderTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoderTest.kt
@@ -141,13 +141,13 @@ class PixelEventDecoderTest {
 
         val result = decoder.decode(event)
 
-        assertThat(result).isInstanceOf(CustomEvent::class.java)
+        assertThat(result).isInstanceOf(CustomPixelEvent::class.java)
 
-        val customEvent = result as CustomEvent
-        assertThat(customEvent.name).isEqualTo("my_custom_event")
-        assertThat(customEvent.timestamp).isEqualTo("2023-12-20T16:39:23+0000")
-        assertThat(customEvent.id).isEqualTo("sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B")
-        val customData = Json.decodeFromString<ExampleClientDefinedType>(customEvent.customData!!)
+        val customPixelEvent = result as CustomPixelEvent
+        assertThat(customPixelEvent.name).isEqualTo("my_custom_event")
+        assertThat(customPixelEvent.timestamp).isEqualTo("2023-12-20T16:39:23+0000")
+        assertThat(customPixelEvent.id).isEqualTo("sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B")
+        val customData = Json.decodeFromString<ExampleClientDefinedType>(customPixelEvent.customData!!)
         assertThat(customData.a.b.c).isEqualTo("d")
 
         verifyNoInteractions(logWrapper)

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoderTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoderTest.kt
@@ -64,9 +64,9 @@ class PixelEventDecoderTest {
 
         val result = decoder.decode(event)
 
-        assertThat(result).isInstanceOf(CheckoutStartedEvent::class.java)
+        assertThat(result).isInstanceOf(StandardPixelEvent::class.java)
 
-        val checkoutStartedEvent = result as CheckoutStartedEvent
+        val checkoutStartedEvent = result as StandardPixelEvent
         assertThat(checkoutStartedEvent.name).isEqualTo("checkout_started")
         assertThat(checkoutStartedEvent.timestamp).isEqualTo("2023-12-20T16:39:23+0000")
         assertThat(checkoutStartedEvent.id).isEqualTo("sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B")
@@ -104,9 +104,9 @@ class PixelEventDecoderTest {
 
         val result = decoder.decode(event)
 
-        assertThat(result).isInstanceOf(CheckoutCompletedEvent::class.java)
+        assertThat(result).isInstanceOf(StandardPixelEvent::class.java)
 
-        val checkoutStarted = result as CheckoutCompletedEvent
+        val checkoutStarted = result as StandardPixelEvent
         assertThat(checkoutStarted.name).isEqualTo("checkout_completed")
         assertThat(checkoutStarted.timestamp).isEqualTo("2023-12-20T16:39:23+0000")
         assertThat(checkoutStarted.id).isEqualTo("sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B")
@@ -228,9 +228,9 @@ class PixelEventDecoderTest {
 
         val result = decoder.decode(event)
 
-        assertThat(result).isInstanceOf(PageViewedEvent::class.java)
+        assertThat(result).isInstanceOf(StandardPixelEvent::class.java)
 
-        val pageViewedEvent = result as PageViewedEvent
+        val pageViewedEvent = result as StandardPixelEvent
         assertThat(pageViewedEvent.name).isEqualTo("page_viewed")
         assertThat(pageViewedEvent.timestamp).isEqualTo("2023-12-20T16:39:23+0000")
         assertThat(pageViewedEvent.id).isEqualTo("sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B")
@@ -239,37 +239,6 @@ class PixelEventDecoderTest {
             .isEqualTo("https://test-store.myshopify.com/checkouts/cn/Z2NwLXVzLWNlbnRyYWwxOjAxSEs0U1BUSlozNDhFME5KTlM2MVhaOVE3?ew_m=f")
 
         verifyNoInteractions(logWrapper)
-    }
-
-    @Test
-    fun `should return null for a standard event we don't know about`() {
-        val event = """|
-            |{
-            |    "name": "new_standard_event",
-            |    "event": {
-            |        "type": "standard",
-            |        "id": "sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B",
-            |        "name": "new_standard_event",
-            |        "timestamp": "2023-12-20T16:39:23+0000",
-            |        "data": {
-            |            "a": {
-            |                "b": {
-            |                    "c": "d"
-            |                }
-            |            }
-            |        }
-            |    }
-            |}
-        |""".trimMargin()
-            .toWebToSdkEvent()
-
-        val result = decoder.decode(event)
-
-        assertThat(result).isNull()
-        verify(logWrapper).w(
-            "CheckoutBridge",
-            "Unrecognized standard pixel event received 'new_standard_event'"
-        )
     }
 
     @Test

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/analytics/Analytics.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/analytics/Analytics.kt
@@ -1,3 +1,25 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics
 
 import com.shopify.checkoutsheetkit.pixelevents.CustomPixelEvent

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/analytics/Analytics.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/analytics/Analytics.kt
@@ -1,0 +1,70 @@
+package com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics
+
+import com.shopify.checkoutsheetkit.pixelevents.CustomPixelEvent
+import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEvent
+import kotlinx.serialization.json.Json
+
+object Analytics {
+    fun userId(): String  {
+        // return ID associated with user in analytics system
+        return "123"
+    }
+
+    fun record(analyticsEvent: AnalyticsEvent) {
+        // implement record, e.g. via calling analytics sdk function
+    }
+}
+
+data class AnalyticsEvent(
+    val id: String,
+    val name: String,
+    val userId: String,
+    val timestamp: String,
+    val checkoutAmount: Double,
+)
+
+data class FirstCustomEventData(
+    val attr1: Double,
+)
+
+data class SecondCustomEventData(
+    val attr2: Double,
+)
+
+fun StandardPixelEvent.toAnalyticsEvent(): AnalyticsEvent {
+    return AnalyticsEvent(
+        id = id ?: "",
+        name = name ?: "",
+        timestamp = timestamp ?: "",
+        userId = Analytics.userId(),
+        checkoutAmount = data?.checkout?.totalPrice?.amount ?: 0.0
+    )
+}
+fun CustomPixelEvent.toAnalyticsEvent(): AnalyticsEvent? {
+    return when (name) {
+        "first_custom_event" -> {
+            val eventData = Json.decodeFromString<FirstCustomEventData>(customData!!)
+            AnalyticsEvent(
+                id = id ?: "",
+                name = name ?: "",
+                timestamp = timestamp ?: "",
+                userId = Analytics.userId(),
+                checkoutAmount = eventData.attr1,
+            )
+        }
+        "second_custom_event" -> {
+            val eventData = Json.decodeFromString<SecondCustomEventData>(customData!!)
+            AnalyticsEvent(
+                id = id ?: "",
+                name = name ?: "",
+                timestamp = timestamp ?: "",
+                userId = Analytics.userId(),
+                checkoutAmount = eventData.attr2,
+            )
+        }
+        else -> {
+            print("unknown event")
+            null
+        }
+    }
+}

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/CheckoutSdkNavHost.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/CheckoutSdkNavHost.kt
@@ -33,15 +33,23 @@ import com.shopify.checkout_sdk_mobile_buy_integration_sample.AppBarState
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.R
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.cart.CartView
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.cart.CartViewModel
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.Analytics
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.AnalyticsEvent
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.FirstCustomEventData
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.SecondCustomEventData
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.toAnalyticsEvent
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.product.ProductView
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.SettingsView
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.SettingsViewModel
 import com.shopify.checkoutsheetkit.CheckoutException
 import com.shopify.checkoutsheetkit.DefaultCheckoutEventProcessor
+import com.shopify.checkoutsheetkit.pixelevents.CustomPixelEvent
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent
+import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
 
 sealed class Screen(val route: String) {
     object Product : Screen("product")
@@ -105,7 +113,15 @@ fun CheckoutSdkNavHost(
                     }
 
                     override fun onWebPixelEvent(event: PixelEvent) {
-                        // handle pixel events (e.g. transform, augment, and process)
+                        // handle pixel events (e.g. transform, augment, and process), e.g.
+                        val analyticsEvent = when (event) {
+                            is StandardPixelEvent -> event.toAnalyticsEvent()
+                            is CustomPixelEvent -> event.toAnalyticsEvent()
+                        }
+
+                        analyticsEvent?.let {
+                            Analytics.record(analyticsEvent)
+                        }
                     }
                 }
             )

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/CheckoutSdkNavHost.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/CheckoutSdkNavHost.kt
@@ -34,9 +34,6 @@ import com.shopify.checkout_sdk_mobile_buy_integration_sample.R
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.cart.CartView
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.cart.CartViewModel
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.Analytics
-import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.AnalyticsEvent
-import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.FirstCustomEventData
-import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.SecondCustomEventData
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.toAnalyticsEvent
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.product.ProductView
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.SettingsView
@@ -49,7 +46,6 @@ import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
 
 sealed class Screen(val route: String) {
     object Product : Screen("product")


### PR DESCRIPTION
### What are you trying to accomplish?

Use a single StandardPixelEvent data class now that the supported events all have the same shape

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
