### PR TITLE
send prefetch header for preloaded checkouts

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
@@ -83,7 +83,11 @@ public object ShopifyCheckoutSheetKit {
     public fun preload(checkoutUrl: String, context: ComponentActivity) {
         if (!configuration.preloading.enabled) return
         CheckoutWebView.clearCache()
-        CheckoutWebView.cacheableCheckoutView(checkoutUrl, context)
+        CheckoutWebView.cacheableCheckoutView(
+            url = checkoutUrl,
+            activity = context,
+            isPreload = true,
+        )
     }
 
     /**

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -38,6 +38,7 @@ import org.mockito.Mockito.verify
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowLooper
 
 @RunWith(RobolectricTestRunner::class)
 class CheckoutWebViewTest {
@@ -67,6 +68,30 @@ class CheckoutWebViewTest {
         assertThat(shadowOf(view).backgroundColor).isEqualTo(Color.TRANSPARENT)
         assertThat(shadowOf(view).getJavascriptInterface("android").javaClass)
             .isEqualTo(CheckoutBridge::class.java)
+    }
+
+    @Test
+    fun `sends prefetch header for preloads`() {
+        withPreloadingEnabled {
+            val isPreload = true
+            val view = CheckoutWebView.cacheableCheckoutView(URL, activity, isPreload)
+
+            val shadow = shadowOf(view)
+            ShadowLooper.shadowMainLooper().runToEndOfTasks()
+
+            assertThat(shadow.lastAdditionalHttpHeaders.getOrDefault("Sec-Purpose", "")).isEqualTo("prefetch")
+        }
+    }
+
+    @Test
+    fun `does not send prefetch header for preloads`() {
+        val isPreload = false
+        val view = CheckoutWebView.cacheableCheckoutView(URL, activity, isPreload)
+
+        val shadow = shadowOf(view)
+        ShadowLooper.shadowMainLooper().runToEndOfTasks()
+
+        assertThat(shadow.lastAdditionalHttpHeaders.getOrDefault("Sec-Purpose", "")).isEqualTo("")
     }
 
     @Test


### PR DESCRIPTION
### What are you trying to accomplish?

Allow differentiating between preloads and normal loads on the backend by sending a prefetch header for preloaded checkouts.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
