### PR TITLE
increase sample app lifeccyle method call visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ val processor = object : WebEventProcessor {
 
     override fun onCheckoutCanceled() {
         // Called when the checkout was canceled by the buyer.
+        // Note: this is also called when checkout is closed after a successful purchase
     }
 
     override fun onCheckoutFailed(error: CheckoutException) {

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/CheckoutSdkNavHost.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/CheckoutSdkNavHost.kt
@@ -22,6 +22,7 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.common.navigation
 
+import android.content.Context
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
@@ -30,7 +31,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.AppBarState
-import com.shopify.checkout_sdk_mobile_buy_integration_sample.R
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.cart.CartView
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.cart.CartViewModel
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.Analytics
@@ -72,6 +72,17 @@ fun CheckoutSdkNavHost(
     settingsViewModel: SettingsViewModel,
     setAppBarState: (AppBarState) -> Unit,
 ) {
+
+    fun showToast(context: Context, text: String) {
+        GlobalScope.launch(Dispatchers.Main) {
+            Toast.makeText(
+                context,
+                text,
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+
     NavHost(
         navController = navController,
         startDestination = startDestination,
@@ -88,6 +99,7 @@ fun CheckoutSdkNavHost(
                 setAppBarState = setAppBarState,
                 checkoutEventProcessor = object : DefaultCheckoutEventProcessor(activity) {
                     override fun onCheckoutCompleted() {
+                        showToast(activity, "Checkout completed")
                         cartViewModel.clearCart()
                         GlobalScope.launch(Dispatchers.Main) {
                             navController.popBackStack(Screen.Product.route, false)
@@ -95,17 +107,12 @@ fun CheckoutSdkNavHost(
                     }
 
                     override fun onCheckoutFailed(error: CheckoutException) {
-                        GlobalScope.launch(Dispatchers.Main) {
-                            Toast.makeText(
-                                activity,
-                                activity.getText(R.string.checkout_error),
-                                Toast.LENGTH_SHORT
-                            ).show()
-                        }
+                        showToast(activity, "Checkout failed with error ${error.message}")
                     }
 
                     override fun onCheckoutCanceled() {
                         // optionally respond to checkout being canceled/closed
+                        showToast(activity, "Checkout canceled")
                     }
 
                     override fun onWebPixelEvent(event: PixelEvent) {

--- a/samples/MobileBuyIntegration/app/src/main/res/values/strings.xml
+++ b/samples/MobileBuyIntegration/app/src/main/res/values/strings.xml
@@ -4,5 +4,4 @@
     <string name="color_scheme_dark">Dark</string>
     <string name="color_scheme_web">Web</string>
     <string name="color_scheme_automatic">Automatic</string>
-    <string name="checkout_error">Checkout failed, please try again</string>
 </resources>


### PR DESCRIPTION
### What are you trying to accomplish?

Increases visibility of lifecycle calls in the sample app, by showing a toast when the methods are invoked.
Excludes pixels for now, to avoid many overlapping toasts.

Small README clarification.

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
