### PR TITLE
fix padding and use theme colors

### DIFF
--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogOverview.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogOverview.kt
@@ -26,22 +26,24 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.logs.Logs.OVERVIEW_FONT_SIZE
 
 @Composable
-fun LogOverviewRow(log: PrettyLog, onClick: () -> Unit, modifier: Modifier) {
+fun LogOverview(log: PrettyLog, onClick: () -> Unit, modifier: Modifier) {
     Row(modifier) {
-
         Text(
             text = log.formattedDate,
             fontSize = OVERVIEW_FONT_SIZE,
+            color = MaterialTheme.colors.onSurface,
             modifier = Modifier.weight(Logs.DATE_COLUMN_WEIGHT).fillMaxHeight().align(Alignment.CenterVertically)
         )
 

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogOverviewHeader.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogOverviewHeader.kt
@@ -22,23 +22,16 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.logs
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import com.shopify.checkout_sdk_mobile_buy_integration_sample.logs.Logs.ROW_COLOR
 
 @Composable
-fun LogOverviewHeader() {
-    Row(
-        Modifier
-            .background(ROW_COLOR)
-            .padding(horizontal = 0.dp, vertical = 8.dp)
-    ) {
-        Text(text = "Date", modifier = Modifier.weight(Logs.DATE_COLUMN_WEIGHT))
-        Text(text = "Type", modifier = Modifier.weight(Logs.MESSAGE_COLUMN_WEIGHT))
+fun LogOverviewHeader(modifier: Modifier) {
+    Row(modifier) {
+        Text(text = "Date", color = MaterialTheme.colors.onSurface, modifier = Modifier.weight(Logs.DATE_COLUMN_WEIGHT))
+        Text(text = "Type", color = MaterialTheme.colors.onSurface, modifier = Modifier.weight(Logs.MESSAGE_COLUMN_WEIGHT))
     }
 }

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogsView.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogsView.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -88,15 +89,23 @@ fun LogsView(
             LazyColumn(
                 Modifier
                     .fillMaxSize()
-                    .padding(PaddingValues(top = 0.dp, end = 8.dp, bottom = 12.dp, start = 8.dp))
+                    .padding(PaddingValues(top = 0.dp, end = 0.dp, bottom = 12.dp, start = 0.dp))
             ) {
                 stickyHeader {
-                    LogOverviewHeader()
+                    LogOverviewHeader(Modifier
+                        .background(MaterialTheme.colors.background)
+                        .padding(horizontal = 8.dp, vertical = 8.dp)
+                    )
                 }
                 itemsIndexed(logState.logs) {  index, line ->
-                    LogOverviewRow(
+                    LogOverview(
                         log = line,
-                        modifier = Modifier.fillMaxWidth().background(index.rowColor()),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                if (index % 2 == 0) MaterialTheme.colors.surface else MaterialTheme.colors.background
+                            )
+                            .padding(horizontal = 8.dp),
                         onClick = {
                             logDetails.value = line
                             logDetailsDialogOpen.value = true
@@ -108,15 +117,9 @@ fun LogsView(
     }
 }
 
-private fun Int.rowColor(): Color {
-    return if (this % 2 == 0) Color.White
-    else Logs.ROW_COLOR
-}
-
 object Logs {
     const val DATE_FORMAT = "dd/MM/yy HH:mm:ss"
     const val DATE_COLUMN_WEIGHT = 0.25f
     const val MESSAGE_COLUMN_WEIGHT = 0.75f
     val OVERVIEW_FONT_SIZE = 12.sp
-    val ROW_COLOR = Color.hsl(185f, 0.43f, 0.95f)
 }

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/details/LogDetailModal.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/details/LogDetailModal.kt
@@ -22,12 +22,14 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.logs.details
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -47,11 +49,13 @@ fun LogDetailModal(
     Dialog(onDismissRequest = { onDismissRequest() }) {
         Card(modifier = Modifier
             .wrapContentHeight()
-            .fillMaxWidth()) {
+            .fillMaxWidth()
+            .background(MaterialTheme.colors.surface)
+        ) {
             Column(Modifier.verticalScroll(rememberScrollState())) {
                 when (logLine?.type) {
-                    LogType.STANDARD -> LogDetails("Checkout Lifecycle Event", logLine.message)
-                    LogType.ERROR -> LogDetails("Checkout Error", "${logLine.errorDetails}")
+                    LogType.STANDARD -> LogDetails("Checkout Lifecycle Event", logLine.message, Modifier.fillMaxWidth())
+                    LogType.ERROR -> LogDetails("Checkout Error", "${logLine.errorDetails}", Modifier.fillMaxWidth())
                     LogType.STANDARD_PIXEL -> PixelEventDetails(logLine.standardPixelEvent, prettyJson)
                     LogType.CUSTOM_PIXEL -> PixelEventDetails(logLine.customPixelEvent, prettyJson)
                     else -> Text("Unknown log type ${logLine?.type}")

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/details/LogDetails.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/details/LogDetails.kt
@@ -38,8 +38,8 @@ import androidx.compose.ui.unit.sp
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.logs.Logs.OVERVIEW_FONT_SIZE
 
 @Composable
-fun LogDetails(header: String, message: String, color: Color = Color.White) {
-    Row(Modifier.fillMaxWidth().background(color = color)) {
+fun LogDetails(header: String, message: String, modifier: Modifier) {
+    Row(modifier) {
         Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
             Text(header, fontWeight = FontWeight.Medium, fontSize = OVERVIEW_FONT_SIZE)
             Text(message, fontSize = 10.sp, fontFamily = FontFamily.Monospace)

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/details/PixelEventDetails.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/details/PixelEventDetails.kt
@@ -22,9 +22,12 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.logs.details
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.shopify.checkout_sdk_mobile_buy_integration_sample.logs.Logs.ROW_COLOR
 import com.shopify.checkoutsheetkit.pixelevents.Context
 import com.shopify.checkoutsheetkit.pixelevents.CustomPixelEvent
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent
@@ -37,29 +40,31 @@ import kotlinx.serialization.json.Json
 fun PixelEventDetails(
     event: PixelEvent?,
     prettyJson: Json,
-    color: Color = ROW_COLOR,
 ) {
-    LogDetails(header = "Event Name", message = event?.name ?: "", color = color)
-    LogDetails(header = "Timestamp", message = event?.timestamp ?: "")
-    LogDetails(header = "ID", message = event?.id ?: "", color = color)
-    LogDetails(header = "Type", message = event?.type?.name?.lowercase() ?: "")
+    val evenModifier = Modifier.fillMaxWidth().background(color = MaterialTheme.colors.surface)
+    val oddModifier = Modifier.fillMaxWidth().background(color = MaterialTheme.colors.background)
+
+    LogDetails(header = "Event Name", message = event?.name ?: "", evenModifier)
+    LogDetails(header = "Timestamp", message = event?.timestamp ?: "", oddModifier)
+    LogDetails(header = "ID", message = event?.id ?: "", evenModifier)
+    LogDetails(header = "Type", message = event?.type?.name?.lowercase() ?: "", oddModifier)
 
     when (event) {
         is StandardPixelEvent -> {
             LogDetails(
                 header = "Data",
                 message = prettyJson.encodeDataToString<StandardPixelEventData>(event.data),
-                color = color,
+                evenModifier,
             )
-            LogDetails(header = "Context", message = prettyJson.encodeDataToString<Context>(event.context))
+            LogDetails(header = "Context", message = prettyJson.encodeDataToString<Context>(event.context), oddModifier)
         }
         is CustomPixelEvent -> {
             LogDetails(
                 header = "Custom Data",
                 message = event.customData ?: "",
-                color = color,
+                evenModifier,
             )
-            LogDetails(header = "Context", message = prettyJson.encodeDataToString<Context>(event.context))
+            LogDetails(header = "Context", message = prettyJson.encodeDataToString<Context>(event.context), oddModifier)
         }
         else -> {}
     }


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes some of the styling for logs.  The padding wasn't correct, and colors were incorrect in dark theme.

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
