### PR TITLE
Update readme details around the checkout event processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ ShopifyCheckoutSheetKit.preload(checkoutUrl)
 
 ### Monitoring the lifecycle of a checkout session
 
-You can use the `WebEventProcessor` interface to register callbacks for key lifecycle events
+You can extend the `DefaultCheckoutEventProcessor` interface to register callbacks for key lifecycle events
 during the checkout session:
 
 ```kotlin
-val processor = object : WebEventProcessor {
+val processor = object : DefaultCheckoutEventProcessor(activity) {
     override fun onCheckoutCompleted() {
         // Called when the checkout was completed successfully by the buyer.
         // Use this to update UI, reset cart state, etc.
@@ -254,6 +254,8 @@ val processor = object : WebEventProcessor {
 }
 
 ```
+
+_Note_: The `DefaultCheckoutEventProcessor` provides default implementations for current and future callback functions, such as `onLinkClicked()`.
 
 #### Integrating with Web Pixels, monitoring behavioral data
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
         class CheckoutLiquidNotMigratedException :
             CheckoutException("The checkout URL provided has resulted in an error because the store is still using checkout.liquid. Checkout Sheet Kit only supports checkout with extensibility.")
 
-
     }
 
     override fun onCheckoutLinkClicked(uri: Uri) {
@@ -255,7 +254,7 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
 
 ```
 
-_Note_: The `DefaultCheckoutEventProcessor` provides default implementations for current and future callback functions, such as `onLinkClicked()`.
+_Note_: The `DefaultCheckoutEventProcessor` provides default implementations for current and future callback functions (such as `onLinkClicked()`), which can be overridden by clients wanting to change default behavior.
 
 #### Integrating with Web Pixels, monitoring behavioral data
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes outdated interface name appearing in README, and recommends extending `DefaultCheckoutEventProcessor`

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [x] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
