### PR TITLE
Add section to README on customizing the dialog title

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ val automatic = ColorScheme.Automatic(
 
 The current configuration can be obtained by calling `ShopifyCheckoutSheetKit.getConfiguration()`.
 
+### Checkout Dialog Title
+
+To customize the title of the Dialog that the checkout WebView is displayed within, or to provide different values for the various locales your app supports, override the `checkout_web_view_title` String resource in your application, e.g:
+
+```xml
+    <string name="checkout_web_view_title">Buy Now!</string>
+```
+
 ### Preloading
 
 Initializing a checkout session requires communicating with Shopify servers and, depending

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The current configuration can be obtained by calling `ShopifyCheckoutSheetKit.ge
 To customize the title of the Dialog that the checkout WebView is displayed within, or to provide different values for the various locales your app supports, override the `checkout_web_view_title` String resource in your application, e.g:
 
 ```xml
-    <string name="checkout_web_view_title">Buy Now!</string>
+<string name="checkout_web_view_title">Buy Now!</string>
 ```
 
 ### Preloading

--- a/samples/MobileBuyIntegration/app/src/main/res/values/strings.xml
+++ b/samples/MobileBuyIntegration/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="color_scheme_web">Web</string>
     <string name="color_scheme_automatic">Automatic</string>
     <string name="checkout_error">Checkout failed, please try again</string>
+    <string name="checkout_web_view_title">Buy Now!</string>
 </resources>


### PR DESCRIPTION
### What are you trying to accomplish?

Add details to the README on how to set a customized/localized Dialog title.

<img width="1028" alt="Screenshot 2024-02-27 at 11 19 54" src="https://github.com/Shopify/checkout-sheet-kit-android/assets/15106863/1d07ef84-907e-4993-a036-bdba53dd10b3">

<img width="408" alt="Screenshot 2024-02-27 at 11 17 36" src="https://github.com/Shopify/checkout-sheet-kit-android/assets/15106863/5daabcef-7294-45ff-9781-062ce989af1e">

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
