### PR TITLE
Ensure cache is cleared on close if checkout is complete

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -51,6 +51,8 @@ internal class CheckoutDialog(
     context: Context,
 ) : Dialog(context) {
 
+    private var isCheckoutComplete = false
+
     fun start(context: ComponentActivity) {
         setContentView(R.layout.dialog_checkout)
         window?.setLayout(MATCH_PARENT, WRAP_CONTENT)
@@ -74,6 +76,7 @@ internal class CheckoutDialog(
                 closeCheckoutDialogWithError = ::closeCheckoutDialogWithError,
                 setProgressBarVisibility = ::setProgressBarVisibility,
                 updateProgressBarPercentage = ::updateProgressBarPercentage,
+                setCheckoutComplete = ::setCheckoutComplete,
             )
         )
 
@@ -95,7 +98,7 @@ internal class CheckoutDialog(
 
         addCheckoutWebViewToContainer(colorScheme, checkoutWebView)
         setOnCancelListener {
-            CheckoutWebViewContainer.retainCache = ShopifyCheckoutSheetKit.configuration.preloading.enabled
+            CheckoutWebViewContainer.retainCache = ShopifyCheckoutSheetKit.configuration.preloading.enabled && !isCheckoutComplete
             checkoutEventProcessor.onCheckoutCanceled()
         }
 
@@ -146,6 +149,10 @@ internal class CheckoutDialog(
 
     private fun setProgressBarVisibility(visibility: Int) {
         findViewById<ProgressBar>(R.id.progressBar).visibility = visibility
+    }
+
+    private fun setCheckoutComplete() {
+        isCheckoutComplete = true
     }
 
     internal fun closeCheckoutDialogWithError(error: CheckoutException) {

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -151,7 +151,7 @@ internal class CheckoutDialog(
         findViewById<ProgressBar>(R.id.progressBar).visibility = visibility
     }
 
-    private fun setCheckoutComplete() {
+    internal fun setCheckoutComplete() {
         isCheckoutComplete = true
     }
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
@@ -40,8 +40,10 @@ internal class CheckoutWebViewEventProcessor(
     private val closeCheckoutDialogWithError: (CheckoutException) -> Unit = { CheckoutWebView.clearCache() },
     private val setProgressBarVisibility: (Int) -> Unit = {},
     private val updateProgressBarPercentage: (Int) -> Unit = {},
+    private val setCheckoutComplete: () -> Unit = {}
 ) {
     fun onCheckoutViewComplete(checkoutCompletedEvent: CheckoutCompletedEvent) {
+        setCheckoutComplete()
         eventProcessor.onCheckoutCompleted(checkoutCompletedEvent)
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

The last change was to retain the WebView cache on close, so that it can be re-opened quickly, and matches with swift. This updates that a little to ensure we clear the cache on close when the checkout is complete.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
