### PR TITLE
Use mutable map for additional headers

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -134,7 +134,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
     fun loadCheckout(url: String, isPreload: Boolean) {
         initLoadTime = System.currentTimeMillis()
         Handler(Looper.getMainLooper()).post {
-            val headers = if (isPreload) mapOf("Sec-Purpose" to "prefetch") else emptyMap()
+            val headers = if (isPreload) mutableMapOf("Sec-Purpose" to "prefetch") else mutableMapOf()
             loadUrl(url, headers)
         }
     }


### PR DESCRIPTION
### What are you trying to accomplish?

The docs say `Some older WebView implementations require additionalHttpHeaders to be mutable.`

https://developer.android.com/reference/android/webkit/WebView#loadUrl(java.lang.String,%20java.util.Map%3Cjava.lang.String,java.lang.String%3E)

So, updating additional headers to be a mutable map

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
