### PR TITLE
Mark cache entry as stale on checkout completed

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -280,6 +280,10 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
         internal var cacheEntry: CheckoutWebViewCacheEntry? = null
         internal var cacheClock = CheckoutWebViewCacheClock()
 
+        fun markCacheEntryStale() {
+            cacheEntry = cacheEntry?.copy(timeout = -1)
+        }
+
         fun clearCache(newEntry: CheckoutWebViewCacheEntry? = null) = cacheEntry?.let {
             Handler(Looper.getMainLooper()).post {
                 it.view.destroy()

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -356,7 +356,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
             return key == cacheEntry!!.key && !cacheEntry!!.isStale
         }
 
-        private val isStale: Boolean
+        internal val isStale: Boolean
             get() = abs(timestamp - clock.currentTimeMillis()) >= timeout
     }
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewContainer.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewContainer.kt
@@ -38,7 +38,7 @@ internal class CheckoutWebViewContainer @JvmOverloads constructor(
     // We should only clear the cache and destroy the WebView after it's been removed from it's parent
     override fun onViewRemoved(child: View?) {
         super.onViewRemoved(child)
-        if (child is CheckoutWebView && !retainCache) {
+        if (child is CheckoutWebView && (!retainCache || CheckoutWebView.cacheEntry?.isStale == true)) {
             CheckoutWebView.clearCache()
         }
         retainCache = false

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
@@ -42,6 +42,7 @@ internal class CheckoutWebViewEventProcessor(
     private val updateProgressBarPercentage: (Int) -> Unit = {},
 ) {
     fun onCheckoutViewComplete(checkoutCompletedEvent: CheckoutCompletedEvent) {
+        CheckoutWebView.markCacheEntryStale()
         eventProcessor.onCheckoutCompleted(checkoutCompletedEvent)
     }
 

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewCacheTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewCacheTest.kt
@@ -129,6 +129,24 @@ class CheckoutWebViewCacheTest {
     }
 
     @Test
+    fun `markCacheEntryStale makes the cache entry stale but does not clear the cache or destroy the view`() {
+        withPreloadingEnabled {
+            val viewOne = CheckoutWebView.cacheableCheckoutView(URL, activity, true)
+            CheckoutWebView.markCacheEntryStale()
+
+            assertThat(CheckoutWebView).isNotNull()
+            assertThat(CheckoutWebView.cacheEntry!!.isValid(URL)).isFalse()
+
+            val viewTwo = CheckoutWebView.cacheableCheckoutView(URL, activity, true)
+            shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+            assertThat(viewOne).isNotEqualTo(viewTwo)
+            assertThat(shadowOf(viewOne).lastLoadedUrl).isEqualTo(URL)
+            assertThat(shadowOf(viewTwo).lastLoadedUrl).isEqualTo(URL)
+        }
+    }
+
+    @Test
     fun `web view cache should have a ttl of 5 minutes`() {
         withPreloadingEnabled {
             val now = System.currentTimeMillis()


### PR DESCRIPTION
### What are you trying to accomplish?

Alternative approach to https://github.com/Shopify/checkout-sheet-kit-android/pull/72

Mark the cache as stale on complete, so that it's discarded on next present.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
