### PR TITLE
order completed event type classes, remove unused imports

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
@@ -25,9 +25,9 @@ package com.shopify.checkoutsheetkit
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
-import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
+import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent
 
 /**

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/lifecycleevents/CompletedEvent.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/lifecycleevents/CompletedEvent.kt
@@ -26,33 +26,6 @@ import com.shopify.checkoutsheetkit.pixelevents.MoneyV2
 import kotlinx.serialization.Serializable
 
 @Serializable
-public data class OrderDetails(
-    public val billingAddress: Address? = null,
-    public val cart: CartInfo,
-    public val deliveries: List<DeliveryInfo> = emptyList(),
-    public val email: String? = null,
-    public val id: String,
-    public val paymentMethods: List<PaymentMethod> = emptyList(),
-    public val phone: String? = null,
-)
-
-@Serializable
-public data class CartInfo(
-    public val lines: List<CartLine>,
-    public val price: Price,
-    public val token: String,
-)
-
-@Serializable
-public data class Price(
-    public val discounts: List<Discount>? = emptyList(),
-    public val shipping: MoneyV2? = null,
-    public val subtotal: MoneyV2? = null,
-    public val taxes: MoneyV2? = null,
-    public val total: MoneyV2? = null,
-)
-
-@Serializable
 public data class Address(
     public val address1: String? = null,
     public val address2: String? = null,
@@ -68,26 +41,18 @@ public data class Address(
 )
 
 @Serializable
-public data class PaymentMethod(
-    public val details: Map<String, String>? = emptyMap(),
-    public val type: String,
-)
-
-/**
- * Current possible methods:
- *  SHIPPING, PICK_UP, RETAIL, LOCAL, PICKUP_POINT, NONE
- */
-@Serializable
-public data class DeliveryInfo(
-    public val details: DeliveryDetails,
-    public val method: String,
+public data class CartInfo(
+    public val lines: List<CartLine>,
+    public val price: Price,
+    public val token: String,
 )
 
 @Serializable
-public data class DeliveryDetails(
-    public val additionalInfo: String? = null,
-    public val location: Address? = null,
-    public val name: String? = null,
+public data class CartLineImage(
+    public val altText: String? = null,
+    public val lg: String,
+    public val md: String,
+    public val sm: String,
 )
 
 @Serializable
@@ -102,6 +67,23 @@ public data class CartLine(
 )
 
 @Serializable
+public data class DeliveryDetails(
+    public val additionalInfo: String? = null,
+    public val location: Address? = null,
+    public val name: String? = null,
+)
+
+/**
+ * Current possible methods:
+ *  SHIPPING, PICK_UP, RETAIL, LOCAL, PICKUP_POINT, NONE
+ */
+@Serializable
+public data class DeliveryInfo(
+    public val details: DeliveryDetails,
+    public val method: String,
+)
+
+@Serializable
 public data class Discount(
     public val amount: MoneyV2? = null,
     public val applicationType: String? = null,
@@ -111,9 +93,27 @@ public data class Discount(
 )
 
 @Serializable
-public data class CartLineImage(
-    public val altText: String? = null,
-    public val lg: String,
-    public val md: String,
-    public val sm: String,
+public data class OrderDetails(
+    public val billingAddress: Address? = null,
+    public val cart: CartInfo,
+    public val deliveries: List<DeliveryInfo> = emptyList(),
+    public val email: String? = null,
+    public val id: String,
+    public val paymentMethods: List<PaymentMethod> = emptyList(),
+    public val phone: String? = null,
+)
+
+@Serializable
+public data class PaymentMethod(
+    public val details: Map<String, String>? = emptyMap(),
+    public val type: String,
+)
+
+@Serializable
+public data class Price(
+    public val discounts: List<Discount>? = emptyList(),
+    public val shipping: MoneyV2? = null,
+    public val subtotal: MoneyV2? = null,
+    public val taxes: MoneyV2? = null,
+    public val total: MoneyV2? = null,
 )

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
@@ -32,7 +32,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/CartView.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/CartView.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.AppBarState
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.toDisplayText
-import com.shopify.checkoutsheetkit.CheckoutEventProcessor
 import com.shopify.checkoutsheetkit.DefaultCheckoutEventProcessor
 
 @Composable

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/logs/LogLine.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/logs/LogLine.kt
@@ -34,8 +34,8 @@ import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEvent
 import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEventData
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import java.util.UUID
 import java.util.Date
+import java.util.UUID
 
 @Entity
 data class LogLine(

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/logs/Logger.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/logs/Logger.kt
@@ -22,8 +22,8 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.common.logs
 
-import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
 import com.shopify.checkoutsheetkit.CheckoutException
+import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
 import com.shopify.checkoutsheetkit.pixelevents.CustomPixelEvent
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent
 import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEvent

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/CheckoutSdkNavHost.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/CheckoutSdkNavHost.kt
@@ -41,9 +41,9 @@ import com.shopify.checkout_sdk_mobile_buy_integration_sample.logs.LogsViewModel
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.product.ProductView
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.SettingsView
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.SettingsViewModel
-import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
 import com.shopify.checkoutsheetkit.CheckoutException
 import com.shopify.checkoutsheetkit.DefaultCheckoutEventProcessor
+import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
 import com.shopify.checkoutsheetkit.pixelevents.CustomPixelEvent
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent
 import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEvent

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogOverview.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogOverview.kt
@@ -32,7 +32,6 @@ import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.logs.Logs.OVERVIEW_FONT_SIZE

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogsView.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogsView.kt
@@ -42,7 +42,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.AppBarState

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/details/PixelEventDetails.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/details/PixelEventDetails.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.shopify.checkoutsheetkit.pixelevents.Context
 import com.shopify.checkoutsheetkit.pixelevents.CustomPixelEvent
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent


### PR DESCRIPTION
### What are you trying to accomplish?

Order classes in CompletedEvent alphabetically for easier comparison with swift.
Optimize imports

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
