### PR TITLE
Fix visual bug around full screen modals introduced with progress bar

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -131,8 +131,8 @@ internal class CheckoutDialog(
 
     private fun toggleHeader(modalVisible: Boolean) {
         Handler(Looper.getMainLooper()).post {
-            val visibility = if (modalVisible) GONE else VISIBLE
-            findViewById<Toolbar>(R.id.checkoutSdkHeader).visibility = visibility
+            findViewById<Toolbar>(R.id.checkoutSdkHeader).visibility = if (modalVisible) GONE else VISIBLE
+            findViewById<ProgressBar>(R.id.progressBar).visibility = if (modalVisible) GONE else INVISIBLE
         }
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Set progress bar visibility to GONE to remove the white bar shown at the top of the screen here when full screen modals are displayed:

<img width="372" alt="Screenshot 2024-03-12 at 09 17 52" src="https://github.com/Shopify/checkout-sheet-kit-android/assets/15106863/285f6a00-e02b-4efc-93fb-ab78877318cd">

After:
<img width="367" alt="Screenshot 2024-03-12 at 09 16 16" src="https://github.com/Shopify/checkout-sheet-kit-android/assets/15106863/2a98c086-29e2-463a-bc38-8437851fbf58">

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
