### PR TITLE
increment version numbers and update changelog for v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ override fun onCheckoutCompleted(checkoutCompletedEvent: CheckoutCompletedEvent)
 
 4. The webview cache is no longer cleared on closing the dialog if checkout has not yet completed. This allows quickly reopening the dialog, and matches the behaviour in the swift library. As in swift, if preloading is enabled, it's important to call preload each tim the cart changes to avoid stale checkouts.
 
+5. Upgrade `org.jetbrains.kotlinx:kotlinx-serialization-json` dependency from 1.5.1 to 1.6.3
+
 ## 1.0.0 January 31, 2024
 
 - Checkout Sheet Kit is now generally available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 2.0.0 March 14, 2024
+
+### New Features
+
+1. **Breaking Changes** The loading spinner has been replaced by a progress bar on the webview. This will result in a faster perceived load time for checkout because the SDK will no longer wait for a full page load to show the DOM content.
+
+If you were previously setting the loading spinner color, the field has been renamed from `spinnerColor` to `progressIndicator e.g:
+
+```diff
+Colors(
+	- spinnerColor = Color.ResourceId(R.color.a_color),
+	+ progressIndicator = Color.ResourceId(R.color.a_color),
+)
+```
+
+2. **Breaking Changes** The `onCheckoutCompleted` callback now returns a completed event object, containing details about the order:
+
+```kotlin
+override fun onCheckoutCompleted(checkoutCompletedEvent: CheckoutCompletedEvent) {
+	println(checkoutCompletedEvent.orderDetails.id)
+}
+```
+
+3. **Breaking Changes** The `CheckoutEventProcessor` passed to `present()` must now be a subclass of `DefaultCheckoutEventProcessor`.
+
+4. The webview cache is no longer cleared on closing the dialog if checkout has not yet completed. This allows quickly reopening the dialog, and matches the behaviour in the swift library. As in swift, if preloading is enabled, it's important to call preload each tim the cart changes to avoid stale checkouts.
+
 ## 1.0.0 January 31, 2024
 
 - Checkout Sheet Kit is now generally available

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ your project:
 #### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:$checkoutSdkVersion"
+implementation "com.shopify:checkout-sheet-kit:2.0.0"
 ```
 
 #### Maven
@@ -33,7 +33,7 @@ implementation "com.shopify:checkout-sheet-kit:$checkoutSdkVersion"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>${checkoutSdkVersion}</version>
+   <version>2.0.0</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -18,7 +18,7 @@ def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "2.0.0")
 
 ext {
     app_compat_version = '1.6.1'
-    kotlin_serialization_version = '1.5.1'
+    kotlin_serialization_version = '1.6.3'
 
     androidx_test_version = '1.5.0'
     androidx_junit_ext_version = '1.1.5'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "1.0.0")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "2.0.0")
 
 ext {
     app_compat_version = '1.6.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/lifecycleevents/CheckoutCompletedEventDecoder.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/lifecycleevents/CheckoutCompletedEventDecoder.kt
@@ -29,7 +29,7 @@ import kotlinx.serialization.json.Json
 
 @Serializable
 public data class CheckoutCompletedEvent(
-    public val orderDetails: OrderDetails? = null
+    public val orderDetails: OrderDetails
 )
 
 internal class CheckoutCompletedEventDecoder @JvmOverloads constructor(
@@ -41,7 +41,16 @@ internal class CheckoutCompletedEventDecoder @JvmOverloads constructor(
             decoder.decodeFromString<CheckoutCompletedEvent>(decodedMsg.body)
         } catch (e: Exception) {
             log.e("CheckoutBridge", "Failed to decode CheckoutCompleted event", e)
-            CheckoutCompletedEvent()
+            CheckoutCompletedEvent(
+                orderDetails = OrderDetails(
+                    id = "",
+                    cart = CartInfo(
+                        price = Price(),
+                        token = "",
+                        lines = emptyList()
+                    )
+                )
+            )
         }
     }
 }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutCompletedEventDecoderTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutCompletedEventDecoderTest.kt
@@ -54,7 +54,7 @@ class CheckoutCompletedEventDecoderTest {
         val result = decoder.decode(EXAMPLE_EVENT.toWebToSdkEvent())
         val orderDetails = result.orderDetails
 
-        assertThat(orderDetails?.id).isEqualTo("gid://shopify/OrderIdentity/9697125302294")
+        assertThat(orderDetails.id).isEqualTo("gid://shopify/OrderIdentity/9697125302294")
     }
 
     @Test
@@ -62,7 +62,7 @@ class CheckoutCompletedEventDecoderTest {
         val result = decoder.decode(EXAMPLE_EVENT.toWebToSdkEvent())
         val orderDetails = result.orderDetails
 
-        assertThat(orderDetails?.cart?.lines).isEqualTo(
+        assertThat(orderDetails.cart.lines).isEqualTo(
             listOf(
                 CartLine(
                     image = CartLineImage(
@@ -89,7 +89,7 @@ class CheckoutCompletedEventDecoderTest {
         val result = decoder.decode(EXAMPLE_EVENT.toWebToSdkEvent())
         val orderDetails = result.orderDetails
 
-        assertThat(orderDetails?.cart?.price).isEqualTo(
+        assertThat(orderDetails.cart.price).isEqualTo(
             Price(
                 total = MoneyV2(
                     amount = 13.99,
@@ -117,7 +117,7 @@ class CheckoutCompletedEventDecoderTest {
         val result = decoder.decode(EXAMPLE_EVENT.toWebToSdkEvent())
         val orderDetails = result.orderDetails
 
-        assertThat(orderDetails?.email).isEqualTo("a.user@shopify.com")
+        assertThat(orderDetails.email).isEqualTo("a.user@shopify.com")
     }
 
     @Test
@@ -125,7 +125,7 @@ class CheckoutCompletedEventDecoderTest {
         val result = decoder.decode(EXAMPLE_EVENT.toWebToSdkEvent())
         val orderDetails = result.orderDetails
 
-        assertThat(orderDetails?.billingAddress).isEqualTo(
+        assertThat(orderDetails.billingAddress).isEqualTo(
             Address(
                 city = "Swansea",
                 countryCode = "GB",
@@ -144,7 +144,7 @@ class CheckoutCompletedEventDecoderTest {
         val result = decoder.decode(EXAMPLE_EVENT.toWebToSdkEvent())
         val orderDetails = result.orderDetails
 
-        assertThat(orderDetails?.paymentMethods).isEqualTo(
+        assertThat(orderDetails.paymentMethods).isEqualTo(
             listOf(
                 PaymentMethod(
                     type = "wallet",
@@ -163,7 +163,7 @@ class CheckoutCompletedEventDecoderTest {
         val result = decoder.decode(EXAMPLE_EVENT.toWebToSdkEvent())
         val orderDetails = result.orderDetails
 
-        assertThat(orderDetails?.deliveries).isEqualTo(
+        assertThat(orderDetails.deliveries).isEqualTo(
             listOf(
                 DeliveryInfo(
                     method = "SHIPPING",

--- a/samples/MobileBuyIntegration/app/build.gradle
+++ b/samples/MobileBuyIntegration/app/build.gradle
@@ -29,7 +29,7 @@ android {
         applicationId "com.shopify.checkout_sdk_mobile_buy_integration_sample"
         minSdk 23
         targetSdk 34
-        versionCode 25
+        versionCode 26
         versionName "0.0.${versionCode}"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
### What are you trying to accomplish?

increment version numbers and update changelog for v2

Make orderDetails non-null on onCheckoutCompleted

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
