### PR TITLE
add second address preference to demo buyer identity

### DIFF
--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/DemoBuyerIdentity.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/DemoBuyerIdentity.kt
@@ -48,6 +48,18 @@ object DemoBuyerIdentity {
                         .setProvince("AB")
                         .setPhone("+441792123456")
                         .setZip("T1X 0L3")
+                ),
+                Storefront.DeliveryAddressInput().setDeliveryAddress(
+                    Storefront.MailingAddressInput()
+                        .setAddress1("8 Lon Heddwch")
+                        .setAddress2("Llansamlet")
+                        .setCity("Swansea")
+                        .setCountry("GB")
+                        .setFirstName("Ada")
+                        .setLastName("Lovelace")
+                        .setProvince("")
+                        .setPhone("+441792123456")
+                        .setZip("SA7 9UY")
                 )
             )
         )


### PR DESCRIPTION
### What are you trying to accomplish?

Add second address to demo buyer identity to test multiple vaulted addresses

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
