### PR TITLE
checkout_completed to cart_completed, make renderProcessGone recovera…

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutBridge.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutBridge.kt
@@ -29,8 +29,6 @@ import com.shopify.checkoutsheetkit.CheckoutBridge.CheckoutWebOperation.ERROR
 import com.shopify.checkoutsheetkit.CheckoutBridge.CheckoutWebOperation.MODAL
 import com.shopify.checkoutsheetkit.CheckoutBridge.CheckoutWebOperation.WEB_PIXELS
 import com.shopify.checkoutsheetkit.errorevents.CheckoutErrorDecoder
-import com.shopify.checkoutsheetkit.errorevents.CheckoutErrorGroup
-import com.shopify.checkoutsheetkit.errorevents.CheckoutErrorPayload
 import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEventDecoder
 import com.shopify.checkoutsheetkit.pixelevents.PixelEventDecoder
 import kotlinx.serialization.Serializable

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutException.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutException.kt
@@ -46,6 +46,7 @@ public class CheckoutSheetKitException(
         public companion object {
             public const val ERROR_SENDING_MESSAGE_TO_CHECKOUT: String = "error_sending_message"
             public const val ERROR_RECEIVING_MESSAGE_FROM_CHECKOUT: String = "error_receiving_message"
+            public const val RENDER_PROCESS_GONE: String = "render_process_gone"
             public const val UNKNOWN: String = "unknown"
         }
 }
@@ -99,7 +100,8 @@ public class CheckoutExpiredException @JvmOverloads constructor(
     isRecoverable,
 ) {
         public companion object {
-            public const val CHECKOUT_EXPIRED: String = "checkout_expired"
+            public const val CART_EXPIRED: String = "cart_expired"
+            public const val CART_COMPLETED: String = "cart_completed"
             public const val INVALID_CART: String = "invalid_cart"
             public const val UNKNOWN: String = "unknown"
         }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -33,7 +33,6 @@ import android.os.Looper
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.View
-import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.webkit.RenderProcessGoneDetail
@@ -165,10 +164,13 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
         override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !detail.didCrash()) {
                 // Renderer was killed because system ran out of memory.
-
-                // Removing the view from `CheckoutWebViewContainer will trigger a cache clear
-                // and call webView.destroy()
-                (view.parent as ViewGroup).removeView(view)
+                checkoutBridge.getEventProcessor().onCheckoutViewFailedWithError(
+                    CheckoutSheetKitException(
+                        errorDescription = "Render process gone.",
+                        errorCode = CheckoutSheetKitException.RENDER_PROCESS_GONE,
+                        isRecoverable = true,
+                    )
+                )
                 true
             } else {
                 false
@@ -274,7 +276,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
                     errorCode == HTTP_GONE -> processor.onCheckoutViewFailedWithError(
                         CheckoutExpiredException(
                             isRecoverable = false,
-                            errorCode = CheckoutExpiredException.CHECKOUT_EXPIRED
+                            errorCode = CheckoutExpiredException.CART_EXPIRED
                         ),
                     )
                     else -> processor.onCheckoutViewFailedWithError(

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/errorevents/CheckoutErrorDecoder.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/errorevents/CheckoutErrorDecoder.kt
@@ -72,16 +72,10 @@ internal class CheckoutErrorDecoder @JvmOverloads constructor(
                     errorDescription = this.reason,
                     isRecoverable = true,
                 )
-            this.group == CheckoutErrorGroup.EXPIRED && this.code == INVALID_CART ->
-                CheckoutExpiredException(
-                    errorDescription = this.reason,
-                    errorCode = CheckoutExpiredException.INVALID_CART,
-                    isRecoverable = false,
-                )
             this.group == CheckoutErrorGroup.EXPIRED ->
                 CheckoutExpiredException(
                     errorDescription = this.reason,
-                    errorCode = CheckoutExpiredException.CHECKOUT_EXPIRED,
+                    errorCode = this.expiredErrorCode(),
                     isRecoverable = false,
                 )
             else -> {
@@ -91,9 +85,18 @@ internal class CheckoutErrorDecoder @JvmOverloads constructor(
         }
     }
 
+    private fun CheckoutErrorPayload.expiredErrorCode(): String {
+        return when (this.code) {
+            INVALID_CART -> CheckoutExpiredException.INVALID_CART
+            CART_COMPLETED -> CheckoutExpiredException.CART_COMPLETED
+            else -> CheckoutExpiredException.CART_EXPIRED
+        }
+    }
+
     companion object {
         private const val CUSTOMER_ACCOUNT_REQUIRED = "customer_account_required"
         private const val STOREFRONT_PASSWORD_REQUIRED = "storefront_password_required"
         private const val INVALID_CART = "invalid_cart"
+        private const val CART_COMPLETED = "cart_completed"
     }
 }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/lifecycleevents/CheckoutCompletedEventDecoder.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/lifecycleevents/CheckoutCompletedEventDecoder.kt
@@ -41,16 +41,7 @@ internal class CheckoutCompletedEventDecoder @JvmOverloads constructor(
             decoder.decodeFromString<CheckoutCompletedEvent>(decodedMsg.body)
         } catch (e: Exception) {
             log.e("CheckoutBridge", "Failed to decode CheckoutCompleted event", e)
-            CheckoutCompletedEvent(
-                orderDetails = OrderDetails(
-                    id = "",
-                    cart = CartInfo(
-                        price = Price(),
-                        token = "",
-                        lines = emptyList()
-                    )
-                )
-            )
+           emptyCompletedEvent()
         }
     }
 }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/lifecycleevents/CompletedEvent.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/lifecycleevents/CompletedEvent.kt
@@ -117,3 +117,16 @@ public data class Price(
     public val taxes: MoneyV2? = null,
     public val total: MoneyV2? = null,
 )
+
+internal fun emptyCompletedEvent(id: String? = null): CheckoutCompletedEvent {
+    return CheckoutCompletedEvent(
+        orderDetails = OrderDetails(
+            cart = CartInfo(
+                token = "",
+                lines = emptyList(),
+                price = Price()
+            ),
+            id = id ?: "",
+        )
+    )
+}

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutBridgeTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutBridgeTest.kt
@@ -248,7 +248,7 @@ class CheckoutBridgeTest {
             |   "name":"error",
             |   "body": "[{
             |       \"group\": \"expired\",
-            |       \"reason\": \"Cart is invalid\",
+            |       \"reason\": \"Checkout has been completed\",
             |       \"flowType\": \"regular\",
             |       \"code\": \"cart_completed\"
             |   }]"
@@ -262,9 +262,9 @@ class CheckoutBridgeTest {
 
         val error = captor.firstValue
         assertThat(error).isInstanceOf(CheckoutExpiredException::class.java)
-        assertThat(error.message).isEqualTo("Cart is invalid")
+        assertThat(error.message).isEqualTo("Checkout has been completed")
         assertThat(error.isRecoverable).isFalse()
-        assertThat(error.errorCode).isEqualTo(CheckoutExpiredException.CHECKOUT_EXPIRED)
+        assertThat(error.errorCode).isEqualTo(CheckoutExpiredException.CART_COMPLETED)
     }
 
 
@@ -290,7 +290,7 @@ class CheckoutBridgeTest {
             "Checkout is no longer available with the provided token. Please generate a new checkout URL"
         )
         assertThat(error.isRecoverable).isFalse()
-        assertThat(error.errorCode).isEqualTo(CheckoutExpiredException.CHECKOUT_EXPIRED)
+        assertThat(error.errorCode).isEqualTo(CheckoutExpiredException.CART_EXPIRED)
     }
 
     @Test

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/errors/CheckoutErrorDecoderTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/errors/CheckoutErrorDecoderTest.kt
@@ -32,7 +32,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.mockito.Mockito
-import java.lang.RuntimeException
 
 class CheckoutErrorDecoderTest {
 


### PR DESCRIPTION
### What are you trying to accomplish?

Some prep work for Graceful degradation:

- make renderProcessGone errors recoverable
- use try-with-resources in the `InteropTest`
- add test for setting and getting configuration in `InteropTest`
- return `cart_completed` events under `CheckoutExpiredException`s as well as `invalid_cart` and `cart_expired`
- remove unused/unnecessary imports in `CheckoutBridge` and `CheckoutErrorDecoder` test
- extract a `emptyCheckoutCompletedEvent()` function so that it can be reused (soon)

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
