### PR TITLE
The present function returns the Dialog so it can be dismissed at a later time

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
@@ -97,15 +97,16 @@ public object ShopifyCheckoutSheetKit {
      * @param context The context the checkout is being presented from
      * @param checkoutEventProcessor provides callbacks to allow clients to listen for and respond to checkout lifecycle events such as
      * (failure, completion, cancellation, external link clicks).
+     * @return the Dialog presented
      */
     @JvmStatic
     public fun <T: DefaultCheckoutEventProcessor> present(
         checkoutUrl: String,
         context: ComponentActivity,
         checkoutEventProcessor: T
-    ) {
+    ): CheckoutDialog? {
         if (context.isDestroyed || context.isFinishing) {
-            return
+            return null
         }
         val dialog = CheckoutDialog(checkoutUrl, checkoutEventProcessor, context)
         context.lifecycle.addObserver(object: DefaultLifecycleObserver {
@@ -115,5 +116,6 @@ public object ShopifyCheckoutSheetKit {
             }
         })
         dialog.start(context)
+        return dialog
     }
 }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
@@ -22,6 +22,7 @@
  */
 package com.shopify.checkoutsheetkit
 
+import android.app.Dialog
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -104,7 +105,7 @@ public object ShopifyCheckoutSheetKit {
         checkoutUrl: String,
         context: ComponentActivity,
         checkoutEventProcessor: T
-    ): CheckoutDialog? {
+    ): Dialog? {
         if (context.isDestroyed || context.isFinishing) {
             return null
         }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
@@ -98,14 +98,14 @@ public object ShopifyCheckoutSheetKit {
      * @param context The context the checkout is being presented from
      * @param checkoutEventProcessor provides callbacks to allow clients to listen for and respond to checkout lifecycle events such as
      * (failure, completion, cancellation, external link clicks).
-     * @return the Dialog presented
+     * @return An instance of [CheckoutSheetKitDialog] if the dialog was successfully created and displayed.
      */
     @JvmStatic
     public fun <T: DefaultCheckoutEventProcessor> present(
         checkoutUrl: String,
         context: ComponentActivity,
         checkoutEventProcessor: T
-    ): Dialog? {
+    ): CheckoutSheetKitDialog? {
         if (context.isDestroyed || context.isFinishing) {
             return null
         }
@@ -117,6 +117,17 @@ public object ShopifyCheckoutSheetKit {
             }
         })
         dialog.start(context)
-        return dialog
+        return CheckoutSheetKitDialog { dialog.dismiss() }
     }
+}
+
+/**
+ * A checkout sheet dialog. Use the [dismiss] method to dismiss the presented dialog
+ */
+@FunctionalInterface
+public fun interface CheckoutSheetKitDialog {
+    /**
+     * Dismisses the checkout sheet dialog.
+     */
+    public fun dismiss()
 }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
@@ -22,7 +22,6 @@
  */
 package com.shopify.checkoutsheetkit
 
-import android.app.Dialog
 import androidx.activity.ComponentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner


### PR DESCRIPTION
### What are you trying to accomplish?

Have the possibility to dismiss the `CheckoutDialog` once the checkout is completed. 
At the moment this is not possible since we don't have the instance of the dialog created so we can't call `dismiss` on it.
With this PR the `CheckoutDialog` reference is returned so it can be used later to dismiss it.

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
