### PR TITLE
refactor user agent setting, set beta release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 3.0.0 April 19, 2024
+## 3.0.0 May 10, 2024
 
-- Improves error handling. See [Error Handling Guidance](https://github.com/Shopify/checkout-sheet-kit-android#error-handling-guidance) for more information.
+- Improved error handling. Attempts to load checkout in a recovery WebView when certain errors are encountered. See [Error Handling](https://github.com/Shopify/checkout-sheet-kit-android#error-handling) for more information.
 
 ## 2.0.1 March 19, 2024
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.0.0")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.0.0-beta.1")
 
 ext {
     app_compat_version = '1.6.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -52,6 +52,8 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
 
     abstract fun getEventProcessor(): CheckoutWebViewEventProcessor
     abstract val recoverErrors: Boolean
+    abstract val variant: String
+    abstract val cspSchema: String
 
     private fun configureWebView() {
         visibility = VISIBLE
@@ -79,6 +81,13 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
         }
         return super.onKeyDown(keyCode, event)
     }
+
+    internal fun userAgentSuffix(): String {
+        val theme = ShopifyCheckoutSheetKit.configuration.colorScheme.id
+        val version = ShopifyCheckoutSheetKit.version.split("-").first()
+        return "ShopifyCheckoutSDK/${version} ($cspSchema;$theme;$variant)"
+    }
+
     open inner class BaseWebViewClient : WebViewClient() {
         init {
             if (BuildConfig.DEBUG) {

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutBridge.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutBridge.kt
@@ -137,8 +137,7 @@ internal class CheckoutBridge(
     }
 
     companion object {
-        private const val SDK_VERSION_NUMBER: String = BuildConfig.SDK_VERSION
-        private const val SCHEMA_VERSION_NUMBER: String = "8.1"
+        const val SCHEMA_VERSION_NUMBER: String = "8.1"
 
         private fun dispatchMessageTemplate(body: String) = """|
         |if (window.MobileCheckoutSdk && window.MobileCheckoutSdk.dispatchMessage) {
@@ -149,11 +148,6 @@ internal class CheckoutBridge(
         |    }, {passive: true, once: true});
         |}
         |""".trimMargin()
-
-        fun userAgentSuffix(): String {
-            val theme = ShopifyCheckoutSheetKit.configuration.colorScheme.id
-            return "ShopifyCheckoutSDK/$SDK_VERSION_NUMBER ($SCHEMA_VERSION_NUMBER;$theme;standard)"
-        }
     }
 }
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -40,6 +40,8 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
     BaseWebView(context, attributeSet) {
 
     override val recoverErrors = true
+    override val variant = "standard"
+    override val cspSchema = CheckoutBridge.SCHEMA_VERSION_NUMBER
 
     private val checkoutBridge = CheckoutBridge(CheckoutWebViewEventProcessor(NoopEventProcessor()))
     private var loadComplete = false
@@ -64,7 +66,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
     init {
         webViewClient = CheckoutWebViewClient()
         addJavascriptInterface(checkoutBridge, JAVASCRIPT_INTERFACE_NAME)
-        settings.userAgentString = "${settings.userAgentString} ${CheckoutBridge.userAgentSuffix()}"
+        settings.userAgentString = "${settings.userAgentString} ${userAgentSuffix()}"
     }
 
     fun hasFinishedLoading() = loadComplete

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/FallbackWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/FallbackWebView.kt
@@ -31,14 +31,14 @@ import com.shopify.checkoutsheetkit.lifecycleevents.emptyCompletedEvent
 internal class FallbackWebView(context: Context, attributeSet: AttributeSet? = null) :
     BaseWebView(context, attributeSet) {
 
+    override val recoverErrors = false
+    override val variant = "standard_recovery"
+    override val cspSchema = "noconnect"
+
     init {
         webViewClient = FallbackWebViewClient()
-        val theme = ShopifyCheckoutSheetKit.configuration.colorScheme.id
-        val suffix = "ShopifyCheckoutSDK/${BuildConfig.SDK_VERSION} (noconnect;$theme;standard_recovery)"
-        settings.userAgentString = "${settings.userAgentString} $suffix"
+        settings.userAgentString = "${settings.userAgentString} ${userAgentSuffix()}"
     }
-
-    override val recoverErrors = false
 
     private var checkoutEventProcessor = CheckoutWebViewEventProcessor(NoopEventProcessor())
 

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutBridgeTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutBridgeTest.kt
@@ -94,36 +94,6 @@ class CheckoutBridgeTest {
     }
 
     @Test
-    fun `user agent suffix includes ShopifyCheckoutSDK and version number`() {
-        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Dark()
-        assertThat(CheckoutBridge.userAgentSuffix()).startsWith("ShopifyCheckoutSDK/${BuildConfig.SDK_VERSION} ")
-    }
-
-    @Test
-    fun `user agent suffix includes metadata for the schema version, theme, and variant - dark`() {
-        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Dark()
-        assertThat(CheckoutBridge.userAgentSuffix()).endsWith("(8.1;dark;standard)")
-    }
-
-    @Test
-    fun `user agent suffix includes metadata for the schema version, theme, and variant - light`() {
-        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Light()
-        assertThat(CheckoutBridge.userAgentSuffix()).endsWith("(8.1;light;standard)")
-    }
-
-    @Test
-    fun `user agent suffix includes metadata for the schema version, theme, and variant - web`() {
-        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Web()
-        assertThat(CheckoutBridge.userAgentSuffix()).endsWith("(8.1;web_default;standard)")
-    }
-
-    @Test
-    fun `user agent suffix includes metadata for the schema version, theme, and variant - automatic`() {
-        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Automatic()
-        assertThat(CheckoutBridge.userAgentSuffix()).endsWith("(8.1;automatic;standard)")
-    }
-
-    @Test
     fun `sendMessage evaluates javascript on the provided WebView`() {
         val webView = mock<WebView>()
         checkoutBridge.sendMessage(webView, CheckoutBridge.SDKOperation.Presented)

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -61,7 +61,6 @@ class CheckoutWebViewTest {
         assertThat(view.visibility).isEqualTo(VISIBLE)
         assertThat(view.settings.javaScriptEnabled).isTrue
         assertThat(view.settings.domStorageEnabled).isTrue
-        assertThat(view.settings.userAgentString).contains("ShopifyCheckoutSDK")
         assertThat(view.layoutParams.height).isEqualTo(MATCH_PARENT)
         assertThat(view.layoutParams.width).isEqualTo(MATCH_PARENT)
         assertThat(view.id).isNotNull
@@ -69,6 +68,46 @@ class CheckoutWebViewTest {
         assertThat(shadowOf(view).backgroundColor).isEqualTo(Color.TRANSPARENT)
         assertThat(shadowOf(view).getJavascriptInterface("android").javaClass)
             .isEqualTo(CheckoutBridge::class.java)
+    }
+
+    @Test
+    fun `user agent suffix includes ShopifyCheckoutSDK and version number`() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Dark()
+        val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
+
+        assertThat(view.settings.userAgentString).contains("ShopifyCheckoutSDK/3.0.0 ")
+    }
+
+    @Test
+    fun `user agent suffix includes metadata for the schema version, theme, and variant - dark`() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Dark()
+        val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
+
+        assertThat(view.settings.userAgentString).endsWith("(8.1;dark;standard)")
+    }
+
+    @Test
+    fun `user agent suffix includes metadata for the schema version, theme, and variant - light`() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Light()
+        val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
+
+        assertThat(view.settings.userAgentString).endsWith("(8.1;light;standard)")
+    }
+
+    @Test
+    fun `user agent suffix includes metadata for the schema version, theme, and variant - web`() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Web()
+        val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
+
+        assertThat(view.settings.userAgentString).endsWith("(8.1;web_default;standard)")
+    }
+
+    @Test
+    fun `user agent suffix includes metadata for the schema version, theme, and variant - automatic`() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Automatic()
+        val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
+
+        assertThat(view.settings.userAgentString).endsWith("(8.1;automatic;standard)")
     }
 
     @Test

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/FallbackWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/FallbackWebViewTest.kt
@@ -46,13 +46,57 @@ class FallbackWebViewTest {
             assertThat(view.visibility).isEqualTo(VISIBLE)
             assertThat(view.settings.javaScriptEnabled).isTrue
             assertThat(view.settings.domStorageEnabled).isTrue
-            assertThat(view.settings.userAgentString).contains("ShopifyCheckoutSDK/${BuildConfig.SDK_VERSION} (noconnect")
             assertThat(view.layoutParams.height).isEqualTo(MATCH_PARENT)
             assertThat(view.layoutParams.width).isEqualTo(MATCH_PARENT)
             assertThat(view.id).isNotNull
             assertThat(shadowOf(view).webViewClient.javaClass).isEqualTo(FallbackWebView.FallbackWebViewClient::class.java)
             assertThat(shadowOf(view).backgroundColor).isEqualTo(Color.TRANSPARENT)
             assertThat(shadowOf(view).getJavascriptInterface("android")).isNull()
+        }
+    }
+
+    @Test
+    fun `user agent suffix includes ShopifyCheckoutSDK and version number`() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Dark()
+        Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+            val view = FallbackWebView(activityController.get())
+            assertThat(view.settings.userAgentString).contains("ShopifyCheckoutSDK/3.0.0 ")
+        }
+    }
+
+    @Test
+    fun `user agent suffix includes metadata for the schema version, theme, and variant - dark`() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Dark()
+        Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+            val view = FallbackWebView(activityController.get())
+            assertThat(view.settings.userAgentString).endsWith("(noconnect;dark;standard_recovery)")
+        }
+    }
+
+    @Test
+    fun `user agent suffix includes metadata for the schema version, theme, and variant - light`() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Light()
+        Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+            val view = FallbackWebView(activityController.get())
+            assertThat(view.settings.userAgentString).endsWith("(noconnect;light;standard_recovery)")
+        }
+    }
+
+    @Test
+    fun `user agent suffix includes metadata for the schema version, theme, and variant - web`() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Web()
+        Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+            val view = FallbackWebView(activityController.get())
+            assertThat(view.settings.userAgentString).endsWith("(noconnect;web_default;standard_recovery)")
+        }
+    }
+
+    @Test
+    fun `user agent suffix includes metadata for the schema version, theme, and variant - automatic`() {
+        ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Automatic()
+        Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+            val view = FallbackWebView(activityController.get())
+            assertThat(view.settings.userAgentString).endsWith("(noconnect;automatic;standard_recovery)")
         }
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

- Refactor how user agents are set a little to allow for a little code reuse (e.g. around version number and `ShopifyCheckoutSdk`).
- Set version to 3.0.0-beta.1
- Strip the beta part off when setting the UA

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
