### PR TITLE
use default description if reason phrase is blank

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -138,7 +138,7 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
                 handleError(
                     request,
                     errorResponse.statusCode,
-                    errorResponse.reasonPhrase,
+                    errorResponse.reasonPhrase.ifBlank { "HTTP ${errorResponse.statusCode} Error" },
                     errorResponse.responseHeaders,
                 )
             }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/Helpers.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/Helpers.kt
@@ -22,11 +22,77 @@
  */
 package com.shopify.checkoutsheetkit
 
+import org.assertj.core.api.AbstractAssert
+
 fun withPreloadingEnabled(block: () -> Unit) {
     try {
         ShopifyCheckoutSheetKit.configure { it.preloading = Preloading(enabled = true) }
         block()
     } finally {
         ShopifyCheckoutSheetKit.configure { it.preloading = Preloading(enabled = false) }
+    }
+}
+
+class CheckoutExceptionAssert(actual: CheckoutException) :
+    AbstractAssert<CheckoutExceptionAssert, CheckoutException>(actual, CheckoutExceptionAssert::class.java) {
+    companion object {
+        fun assertThat(actual: CheckoutException): CheckoutExceptionAssert {
+            return CheckoutExceptionAssert(actual)
+        }
+    }
+
+    fun isRecoverable(): CheckoutExceptionAssert {
+        isNotNull()
+
+        if (!actual.isRecoverable) {
+            failWithMessage("Expected exception to be recoverable but was not")
+        }
+
+        return this
+    }
+
+    fun isNotRecoverable(): CheckoutExceptionAssert {
+        isNotNull()
+
+        if (actual.isRecoverable) {
+            failWithMessage("Expected exception not to be recoverable but was")
+        }
+
+        return this
+    }
+
+    fun hasDescription(description: String): CheckoutExceptionAssert {
+        isNotNull()
+
+        if (actual.errorDescription != description) {
+            failWithMessage("Expected exception to have description <%s>, but was, <%s>", description, actual.errorDescription)
+        }
+
+        return this
+    }
+
+    fun hasErrorCode(errorCode: String): CheckoutExceptionAssert {
+        isNotNull()
+
+        if (actual.errorCode != errorCode) {
+            failWithMessage("Expected exception to have errorCode <%s>, but was, <%s>", errorCode, actual.errorCode)
+        }
+
+        return this
+    }
+
+    fun hasStatusCode(statusCode: Int): CheckoutExceptionAssert {
+        isNotNull()
+
+        if (actual !is HttpException) {
+            failWithMessage("Cannot assert status code on an exception that is not a HttpException")
+        }
+
+        val actualCode = (actual as HttpException).statusCode
+        if (actualCode != statusCode) {
+            failWithMessage("Expected exception to have statusCode <%s>, but was, <%s>", statusCode, actualCode)
+        }
+
+        return this
     }
 }


### PR DESCRIPTION
### What are you trying to accomplish?

I noticed that the reasonPhrase was empty for a 502 during testing.  This adds a default errorDescription for that case.

Also tries to make the tests a little easier to read by adding a custom assertion class, chaining assertions fluently, and extracting a function to trigger the http error callback.

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
