### PR TITLE
Call onPause when preloading allowing PageVisibility API to return th…

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -68,6 +68,7 @@ internal class CheckoutDialog(
             context,
         )
 
+        checkoutWebView.onResume()
         checkoutWebView.setEventProcessor(eventProcessor())
 
         val colorScheme = ShopifyCheckoutSheetKit.configuration.colorScheme

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -216,6 +216,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
             if (!preloadingEnabled || cacheEntry?.isValid(url) != true) {
                 val view = CheckoutWebView(activity as Context).apply {
                     loadCheckout(url, isPreload)
+                    if (isPreload) onPause()
                 }
 
                 setCacheEntry(

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -216,7 +216,11 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
             if (!preloadingEnabled || cacheEntry?.isValid(url) != true) {
                 val view = CheckoutWebView(activity as Context).apply {
                     loadCheckout(url, isPreload)
-                    if (isPreload) onPause()
+                    if (isPreload) {
+                        // Pauses processing that can be paused safely (e.g. geolocation, animations), but not JavaScript / network requests
+                        // https://developer.android.com/reference/android/webkit/WebView#onPause()
+                        onPause()
+                    }
                 }
 
                 setCacheEntry(

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
@@ -34,6 +34,7 @@ import androidx.core.view.children
 import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
 import com.shopify.checkoutsheetkit.lifecycleevents.emptyCompletedEvent
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 import org.awaitility.Awaitility.await
 import org.junit.After
 import org.junit.Before
@@ -49,6 +50,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowLooper
+import org.robolectric.shadows.ShadowWebView
 import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
@@ -97,6 +99,17 @@ class CheckoutDialogTest {
         await().atMost(2, TimeUnit.SECONDS).until {
             dialog.containsChildOfType(CheckoutWebView::class.java)
         }
+    }
+
+    @Test
+    fun `checkoutView child WebView onResume has been called`() {
+        ShopifyCheckoutSheetKit.present("https://shopify.com", activity, processor)
+
+        val webView: WebView = ShadowDialog.getLatestDialog()
+            .findViewById<CheckoutWebViewContainer>(R.id.checkoutSdkContainer)
+            .children.firstOrNull { it is WebView } as WebView? ?: fail("No WebVew found in dialog")
+
+        assertThat(shadowOf(webView).wasOnResumeCalled()).isTrue()
     }
 
     @Test

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewCacheTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewCacheTest.kt
@@ -75,6 +75,26 @@ class CheckoutWebViewCacheTest {
     }
 
     @Test
+    fun `calls onPause if preloading so the PageVisibility API reports the correct value`() {
+        withPreloadingEnabled {
+            val viewOne = CheckoutWebView.cacheableCheckoutView(URL, activity, true)
+            shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+            assertThat(shadowOf(viewOne).wasOnPauseCalled()).isTrue()
+        }
+    }
+
+    @Test
+    fun `does not call onPause if not preloading`() {
+        withPreloadingEnabled {
+            val viewOne = CheckoutWebView.cacheableCheckoutView(URL, activity, false)
+
+            shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+            assertThat(shadowOf(viewOne).wasOnPauseCalled()).isFalse()
+        }
+    }
+
+    @Test
     fun `cacheableCheckoutView returns the new view if URL has changed`() {
         withPreloadingEnabled {
             val newUrl = "https://another.checkout.url"


### PR DESCRIPTION
…e correct value

### What are you trying to accomplish?

See the issue here for more details on how PageVisbility API and WebViews work together.

https://partnerissuetracker.corp.google.com/issues/40446497

Specifically `So now, if an app wants to toggle blink page visibility, it has to call WebView#onPause/onResume. The visibility of the window that the WebView is attached to is not under control of the app.`

https://developer.android.com/reference/android/webkit/WebView#onPause()

https://github.com/Shopify/checkout-sheet-kit-android/assets/15106863/7db6a072-2f0e-4cbc-ab44-ff2578af0e33

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
