### PR TITLE
use File.readlines instead of IO.readlines

### DIFF
--- a/scripts/check_license_headers.rb
+++ b/scripts/check_license_headers.rb
@@ -6,7 +6,7 @@ files = []
 Find.find('.') do |path|
     next unless File.file?(path) && path.end_with?('.kt')
 
-    lines = IO.readlines(path)
+    lines = File.readlines(path)
 
     files << path unless lines[0].start_with?("/*") && lines[1].start_with?(" * MIT License")
 end


### PR DESCRIPTION
### What are you trying to accomplish?

use File.readlines instead of IO.readlines in our check license headers script

### Before you deploy

- [ ] I have added tests to support my implementation
- [ ] I have read and agree with the [contributing documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md)
- [ ] I have read and agree with the [code of conduct documentation](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated the [README](https://github.com/Shopify/checkout-sheet-kit-android/blob/main/README.md) (if applicable).
