### PR TITLE
Add onPermissionRequest to allow clients to camera permissions for verification apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.2 Jul 26, 2024
+
+- Implements `webChromeClient.onPermissionRequest()` to grant permission to the camera to allow apps that require the camera to verify identity to function correctly.
+- Relevant camera permissions must be added to the client's `AndroidManifest.xml`
+
 ## 3.0.1 May 31, 2024
 
 - Call `onPause()` on the WebView as it's created if preloading, and `onResume()` when it's presented, so the Page Visibility API reports correct values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 3.0.2 Jul 26, 2024
 
-- Implements `webChromeClient.onPermissionRequest()` to grant permission to the camera to allow apps that require the camera to verify identity to function correctly.
-- Relevant camera permissions must be added to the client's `AndroidManifest.xml`
+- Implements `onPermissionRequest()` to call a new `eventProcessor.onPermissionRequest(permissionRequest: PermissionRequest)` callback allowing clients to grant or deny permission requests, or request permissions (e.g. camera, record audio). This is sometimes required for checkouts that use features that require verifying identity.
 
 ## 3.0.1 May 31, 2024
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
         // Called when a web pixel event is emitted in checkout.
         // Use this to submit events to your analytics system, see below.
     }
+
+    override fun onPermissionRequest(permissionRequest: PermissionRequest) {
+        // Called when a permission has been requested, e.g. to access the camera
+        // implement to grant/deny/request permissions.
+    }
 }
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.0.1")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.0.2")
 
 ext {
     app_compat_version = '1.6.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -25,7 +25,6 @@ package com.shopify.checkoutsheetkit
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.pm.PackageManager
 import android.graphics.Color.TRANSPARENT
 import android.os.Build
 import android.util.AttributeSet
@@ -71,30 +70,7 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
                 getEventProcessor().updateProgressBar(newProgress)
             }
             override fun onPermissionRequest(request: PermissionRequest) {
-                request.resources?.forEach { resource ->
-                    if (resource == PermissionRequest.RESOURCE_VIDEO_CAPTURE) {
-                        if (!hasCameraPermission()) {
-                            requestPermissions()
-                            request.deny()
-                        } else {
-                            request.grant(request.resources)
-                        }
-                    }
-                }
-            }
-
-            private fun hasCameraPermission() =
-                ActivityCompat.checkSelfPermission(
-                    context,
-                    Manifest.permission.CAMERA
-                ) == PackageManager.PERMISSION_GRANTED
-
-            private fun requestPermissions() {
-                ActivityCompat.requestPermissions(
-                    context as ComponentActivity,
-                    arrayOf(Manifest.permission.CAMERA),
-                    CAMERA_PERMISSION_REQUEST
-                )
+                getEventProcessor().onPermissionRequest(request)
             }
         }
         isHorizontalScrollBarEnabled = false
@@ -225,7 +201,6 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
     companion object {
         private const val DEPRECATED_REASON_HEADER = "X-Shopify-API-Deprecated-Reason"
         private const val LIQUID_NOT_SUPPORTED = "checkout_liquid_not_supported"
-        private const val CAMERA_PERMISSION_REQUEST = 1
 
         private const val TOO_MANY_REQUESTS = 429
         private val CLIENT_ERROR = 400..499

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -22,7 +22,6 @@
  */
 package com.shopify.checkoutsheetkit
 
-import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color.TRANSPARENT
@@ -40,8 +39,6 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import androidx.activity.ComponentActivity
-import androidx.core.app.ActivityCompat
 import java.net.HttpURLConnection.HTTP_GONE
 import java.net.HttpURLConnection.HTTP_NOT_FOUND
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
@@ -25,6 +25,7 @@ package com.shopify.checkoutsheetkit
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.webkit.PermissionRequest
 import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent
 
@@ -59,6 +60,11 @@ public interface CheckoutEventProcessor {
     public fun onCheckoutLinkClicked(uri: Uri)
 
     /**
+     * A permission has been requested by the web chrome client, e.g. to access the camera
+     */
+    public fun onPermissionRequest(permissionRequest: PermissionRequest)
+
+    /**
      * Web Pixel event emitted from checkout, that can be optionally transformed, enhanced (e.g. with user and session identifiers),
      * and processed
      */
@@ -79,6 +85,9 @@ internal class NoopEventProcessor : CheckoutEventProcessor {
     }
 
     override fun onWebPixelEvent(event: PixelEvent) {/* noop */
+    }
+
+    override fun onPermissionRequest(permissionRequest: PermissionRequest) {/* noop */
     }
 }
 
@@ -103,6 +112,10 @@ public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
 
     override fun onWebPixelEvent(event: PixelEvent) {
         // no-op, override to implement
+    }
+
+    override fun onPermissionRequest(permissionRequest: PermissionRequest) {
+        // no-op override to implement
     }
 
     private fun Context.launchEmailApp(to: String) {

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
@@ -27,6 +27,7 @@ import android.os.Handler
 import android.os.Looper
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
+import android.webkit.PermissionRequest
 import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent
 
@@ -59,6 +60,12 @@ internal class CheckoutWebViewEventProcessor(
     fun onCheckoutViewFailedWithError(error: CheckoutException) {
         onMainThread {
             closeCheckoutDialogWithError(error)
+        }
+    }
+
+    fun onPermissionRequest(permissionRequest: PermissionRequest) {
+        onMainThread {
+            eventProcessor.onPermissionRequest(permissionRequest)
         }
     }
 

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
@@ -49,7 +49,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowLooper
-import org.robolectric.shadows.ShadowWebView
 import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -22,7 +22,6 @@
  */
 package com.shopify.checkoutsheetkit
 
-import android.Manifest
 import android.graphics.Color
 import android.os.Looper
 import android.view.View.VISIBLE

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -84,7 +84,7 @@ class CheckoutWebViewTest {
         ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Dark()
         val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
 
-        assertThat(view.settings.userAgentString).contains("ShopifyCheckoutSDK/3.0.1 ")
+        assertThat(view.settings.userAgentString).contains("ShopifyCheckoutSDK/3.0.2 ")
     }
 
     @Test

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -22,10 +22,12 @@
  */
 package com.shopify.checkoutsheetkit
 
+import android.Manifest
 import android.graphics.Color
 import android.os.Looper
 import android.view.View.VISIBLE
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.webkit.PermissionRequest
 import androidx.activity.ComponentActivity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -37,6 +39,7 @@ import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
@@ -199,6 +202,35 @@ class CheckoutWebViewTest {
 
         shadow.webChromeClient?.onProgressChanged(view, 50)
         verify(webViewEventProcessor).updateProgressBar(50)
+    }
+
+    @Test
+    fun `calls grant when video capture resource permission requested and app has camera permission`() {
+        val application = shadowOf(activity.application)
+        application.grantPermissions(Manifest.permission.CAMERA)
+
+        val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
+        val permissionRequest = mock<PermissionRequest>()
+        val requestedResources = arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE)
+        whenever(permissionRequest.resources).thenReturn(requestedResources)
+
+        val shadow = shadowOf(view)
+        shadow.webChromeClient?.onPermissionRequest(permissionRequest)
+
+        verify(permissionRequest).grant(requestedResources)
+    }
+
+    @Test
+    fun `calls deny when video capture resource permission requested and app does not have camera permission`() {
+        val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
+        val permissionRequest = mock<PermissionRequest>()
+        val requestedResources = arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE)
+        whenever(permissionRequest.resources).thenReturn(requestedResources)
+
+        val shadow = shadowOf(view)
+        shadow.webChromeClient?.onPermissionRequest(permissionRequest)
+
+        verify(permissionRequest).deny()
     }
 
     @Test

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -205,11 +205,11 @@ class CheckoutWebViewTest {
     }
 
     @Test
-    fun `calls grant when video capture resource permission requested and app has camera permission`() {
-        val application = shadowOf(activity.application)
-        application.grantPermissions(Manifest.permission.CAMERA)
-
+    fun `calls processors onPermissionRequest when resource permission requested`() {
         val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
+        val webViewEventProcessor = mock<CheckoutWebViewEventProcessor>()
+        view.setEventProcessor(webViewEventProcessor)
+
         val permissionRequest = mock<PermissionRequest>()
         val requestedResources = arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE)
         whenever(permissionRequest.resources).thenReturn(requestedResources)
@@ -217,20 +217,7 @@ class CheckoutWebViewTest {
         val shadow = shadowOf(view)
         shadow.webChromeClient?.onPermissionRequest(permissionRequest)
 
-        verify(permissionRequest).grant(requestedResources)
-    }
-
-    @Test
-    fun `calls deny when video capture resource permission requested and app does not have camera permission`() {
-        val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
-        val permissionRequest = mock<PermissionRequest>()
-        val requestedResources = arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE)
-        whenever(permissionRequest.resources).thenReturn(requestedResources)
-
-        val shadow = shadowOf(view)
-        shadow.webChromeClient?.onPermissionRequest(permissionRequest)
-
-        verify(permissionRequest).deny()
+        verify(webViewEventProcessor).onPermissionRequest(permissionRequest)
     }
 
     @Test

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/FallbackWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/FallbackWebViewTest.kt
@@ -66,7 +66,7 @@ class FallbackWebViewTest {
         ShopifyCheckoutSheetKit.configuration.colorScheme = ColorScheme.Dark()
         Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
             val view = FallbackWebView(activityController.get())
-            assertThat(view.settings.userAgentString).contains("ShopifyCheckoutSDK/3.0.1 ")
+            assertThat(view.settings.userAgentString).contains("ShopifyCheckoutSDK/3.0.2 ")
         }
     }
 

--- a/samples/MobileBuyIntegration/app/build.gradle
+++ b/samples/MobileBuyIntegration/app/build.gradle
@@ -31,7 +31,7 @@ android {
         applicationId "com.shopify.checkout_sdk_mobile_buy_integration_sample"
         minSdk 23
         targetSdk 34
-        versionCode 31
+        versionCode 32
         versionName "0.0.${versionCode}"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml
+++ b/samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature android:name="android.hardware.camera.any" android:required="false"/>
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <application
         android:name=".MobileBuyIntegration"
         android:allowBackup="true"

--- a/samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml
+++ b/samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml
@@ -3,8 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:name="android.hardware.camera.any" android:required="false"/>
+    <uses-feature android:name="android.hardware.microphone" android:required="false"/>
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <application
         android:name=".MobileBuyIntegration"
         android:allowBackup="true"

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/MobileBuyEventProcessor.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/MobileBuyEventProcessor.kt
@@ -1,0 +1,113 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkout_sdk_mobile_buy_integration_sample.common
+
+import android.Manifest
+import android.content.Context
+import android.webkit.PermissionRequest
+import android.widget.Toast
+import androidx.core.app.ActivityCompat
+import androidx.navigation.NavController
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.R
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.cart.CartViewModel
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.Analytics
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.analytics.toAnalyticsEvent
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.logs.Logger
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.navigation.Screen
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.navigation.getActivity
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.permissions.Permissions
+import com.shopify.checkoutsheetkit.CheckoutException
+import com.shopify.checkoutsheetkit.DefaultCheckoutEventProcessor
+import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
+import com.shopify.checkoutsheetkit.pixelevents.CustomPixelEvent
+import com.shopify.checkoutsheetkit.pixelevents.PixelEvent
+import com.shopify.checkoutsheetkit.pixelevents.StandardPixelEvent
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+@OptIn(DelicateCoroutinesApi::class)
+class MobileBuyEventProcessor(
+    private val cartViewModel: CartViewModel,
+    private val navController: NavController,
+    private val logger: Logger,
+    private val context: Context
+): DefaultCheckoutEventProcessor(context) {
+    override fun onCheckoutCompleted(checkoutCompletedEvent: CheckoutCompletedEvent) {
+        logger.log(checkoutCompletedEvent)
+
+        cartViewModel.clearCart()
+        GlobalScope.launch(Dispatchers.Main) {
+            navController.popBackStack(Screen.Product.route, false)
+        }
+    }
+
+    override fun onCheckoutFailed(error: CheckoutException) {
+        logger.log("Checkout failed", error)
+
+        if (!error.isRecoverable) {
+            GlobalScope.launch(Dispatchers.Main) {
+                Toast.makeText(
+                    context,
+                    context.getText(R.string.checkout_error),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
+    }
+
+    override fun onCheckoutCanceled() {
+        // optionally respond to checkout being canceled/closed
+        logger.log("Checkout canceled")
+    }
+
+    override fun onPermissionRequest(permissionRequest: PermissionRequest) {
+        context.getActivity()?.let { activity ->
+            if (Permissions.hasPermission(activity, permissionRequest)) {
+                permissionRequest.grant(permissionRequest.resources)
+            } else {
+                ActivityCompat.requestPermissions(
+                    activity,
+                    arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO),
+                    Permissions.PERMISSION_REQUEST_CODE,
+                )
+                permissionRequest.deny()
+            }
+        }
+    }
+
+    override fun onWebPixelEvent(event: PixelEvent) {
+        logger.log(event)
+
+        // handle pixel events (e.g. transform, augment, and process), e.g.
+        val analyticsEvent = when (event) {
+            is StandardPixelEvent -> event.toAnalyticsEvent()
+            is CustomPixelEvent -> event.toAnalyticsEvent()
+        }
+
+        analyticsEvent?.let {
+            Analytics.record(analyticsEvent)
+        }
+    }
+}

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/MobileBuyEventProcessor.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/MobileBuyEventProcessor.kt
@@ -83,6 +83,7 @@ class MobileBuyEventProcessor(
     }
 
     override fun onPermissionRequest(permissionRequest: PermissionRequest) {
+        logger.log("Permission requested for ${permissionRequest.resources}")
         context.getActivity()?.let { activity ->
             if (Permissions.hasPermission(activity, permissionRequest)) {
                 permissionRequest.grant(permissionRequest.resources)

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/permissions/Permissions.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/permissions/Permissions.kt
@@ -1,0 +1,55 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkout_sdk_mobile_buy_integration_sample.common.permissions
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.webkit.PermissionRequest
+import androidx.activity.ComponentActivity
+import androidx.core.content.ContextCompat
+
+internal object Permissions {
+    internal fun hasPermission(activity: ComponentActivity, request: PermissionRequest): Boolean {
+        return request.resources.all {
+            when (it) {
+                PermissionRequest.RESOURCE_VIDEO_CAPTURE -> {
+                    VIDEO_PERMISSIONS.all { permission ->
+                        ContextCompat.checkSelfPermission(activity.applicationContext, permission) == PackageManager.PERMISSION_GRANTED
+                    }
+                }
+                PermissionRequest.RESOURCE_AUDIO_CAPTURE -> {
+                    AUDIO_PERMISSIONS.all { permission ->
+                        ContextCompat.checkSelfPermission(activity.applicationContext, permission) == PackageManager.PERMISSION_GRANTED
+                    }
+                }
+                else -> {
+                    false
+                }
+            }
+        }
+    }
+
+    internal val PERMISSION_REQUEST_CODE = 1
+    private val VIDEO_PERMISSIONS = arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
+    private val AUDIO_PERMISSIONS = arrayOf(Manifest.permission.RECORD_AUDIO)
+}


### PR DESCRIPTION
### What changes are you making?

adds an `onPermissionRequest()` function to the CheckoutEventProcessor interface, to allow clients to grants permissions to camera/audio/other. This is required by some 3rd party apps to perform actions like verifying identity. 

See https://github.com/Shopify/checkout-sheet-kit-android/issues/113

### How to test

Open a web page that requires camera access via the sample app.  Ensure the camera can be accessed.

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [x] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
