### PR TITLE
Ensure no existing parent is present before adding to container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.1.1 September 25, 2024
+## 3.1.1 October 2, 2024
 
 - Ensure that cached WebView instances don't have existing parents before trying to add them to their container.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.1 September 25, 2024
+
+- Ensure that cached WebView instances don't have existing parents before trying to add them to their container.
+
 ## 3.1.0 September 6, 2024
 
 - Implement and expose `onShowFileChooser()`, to support clients with checkouts that need to show a native file chooser. Example in the MobileBuyIntegration demo app.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ your project:
 #### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.1.0"
+implementation "com.shopify:checkout-sheet-kit:3.1.1"
 ```
 
 #### Maven
@@ -33,7 +33,7 @@ implementation "com.shopify:checkout-sheet-kit:3.1.0"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.1.0</version>
+   <version>3.1.1</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.1.0")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.1.1")
 
 ext {
     app_compat_version = '1.6.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -30,6 +30,7 @@ import android.os.Build
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.View
+import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.webkit.PermissionRequest
@@ -212,5 +213,17 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
 
         private const val TOO_MANY_REQUESTS = 429
         private val CLIENT_ERROR = 400..499
+    }
+}
+
+/**
+ * Removes the WebView from its parent if a parent exists
+ */
+internal fun BaseWebView.removeFromParent() {
+    val parent = this.parent
+    if (parent is ViewGroup) {
+        // Ensure view is not destroyed when removing from parent
+        CheckoutWebViewContainer.retainCacheEntry = RetainCacheEntry.YES
+        parent.removeView(this)
     }
 }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -89,7 +89,7 @@ internal class CheckoutDialog(
 
         addWebViewToContainer(colorScheme, checkoutWebView)
         setOnCancelListener {
-            CheckoutWebViewContainer.retainCache = ShopifyCheckoutSheetKit.configuration.preloading.enabled
+            CheckoutWebViewContainer.retainCacheEntry = RetainCacheEntry.IF_NOT_STALE
             checkoutEventProcessor.onCheckoutCanceled()
         }
 
@@ -119,12 +119,13 @@ internal class CheckoutDialog(
 
     private fun addWebViewToContainer(
         colorScheme: ColorScheme,
-        checkoutWebView: WebView
+        checkoutWebView: BaseWebView,
     ) {
         findViewById<RelativeLayout>(R.id.checkoutSdkContainer).apply {
             setBackgroundColor(colorScheme.webViewBackgroundColor())
             val layoutParams = RelativeLayout.LayoutParams(WRAP_CONTENT, MATCH_PARENT)
             layoutParams.addRule(RelativeLayout.BELOW, R.id.progressBar)
+            checkoutWebView.removeFromParent()
             addView(checkoutWebView, layoutParams)
         }
     }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewContainer.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewContainer.kt
@@ -38,18 +38,31 @@ internal class CheckoutWebViewContainer @JvmOverloads constructor(
     // We should only clear the cache and destroy the WebView after it's been removed from it's parent
     override fun onViewRemoved(child: View?) {
         super.onViewRemoved(child)
-        if (child is CheckoutWebView && (!retainCache || CheckoutWebView.cacheEntry?.isStale == true)) {
-            CheckoutWebView.clearCache()
+        if (child is CheckoutWebView) {
+           if (retainCacheEntry == RetainCacheEntry.IF_NOT_STALE && CheckoutWebView.cacheEntry?.isStale == true) {
+               CheckoutWebView.clearCache()
+           }
         }
 
         if (child is FallbackWebView) {
             child.destroy()
         }
 
-        retainCache = false
+        retainCacheEntry = RetainCacheEntry.IF_NOT_STALE
     }
 
     companion object {
-        internal var retainCache = false
+        internal var retainCacheEntry = RetainCacheEntry.IF_NOT_STALE
     }
+}
+
+internal enum class RetainCacheEntry {
+    /**
+     * Retain a WebView in the cache if it is not stale
+     */
+    IF_NOT_STALE,
+    /**
+     * Always retain the WebView in the cache, regardless of whether it is stale or not
+     */
+    YES,
 }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -280,6 +280,42 @@ class CheckoutWebViewTest {
         }
     }
 
+    @Test
+    fun `removeFromParent() should remove parent if a parent exists but not destroy WebView`() {
+        withPreloadingEnabled {
+            Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+                val ctx = activityController.get()
+                val webView = CheckoutWebView.cacheableCheckoutView("https://shopify.dev", ctx, true)
+                val container = CheckoutWebViewContainer(ctx)
+                container.addView(webView)
+                assertThat(webView.parent).isNotNull()
+
+                webView.removeFromParent()
+                shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+                val shadow = shadowOf(webView)
+                assertThat(shadow.wasDestroyCalled()).isFalse()
+                assertThat(webView.parent).isNull()
+            }
+        }
+    }
+
+    @Test
+    fun `removeFromParent() should do nothing if no parent exists`() {
+        withPreloadingEnabled {
+            Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+                val ctx = activityController.get()
+                val webView = CheckoutWebView.cacheableCheckoutView("https://shopify.dev", ctx, true)
+                webView.removeFromParent()
+                shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+                val shadow = shadowOf(webView)
+                assertThat(shadow.wasDestroyCalled()).isFalse()
+                assertThat(webView.parent).isNull()
+            }
+        }
+    }
+
     companion object {
         private const val URL = "https://a.checkout.testurl"
     }


### PR DESCRIPTION
### What changes are you making?

CLOSES https://github.com/Shopify/checkout-sheet-kit-android/issues/127

When preloading is enabled and we fetch the checkout web view from the cache, there are some scenarios where we try to add the fetched view to a parent container when it already has a parent (causing an IllegalStateException).

This can be reproduced by enabling preloading, then calling `present()` twice without dismissing the modal (there also may be other cases).

This PR looks to ensure the webView has no existing parent before we add it to its container.

---

Note: When we remove checkout web views from their container, we also look to ensure it's destroyed if we think it will not be used again, to avoid memory leaks. We don't want to do this destroy/cleanup in this case, as the view will be added to the view hierarchy shortly after removing the existing parent and therefore must not be destroyed.

---

### How to test

Add the following below `ShopifyCheckoutSheetKit.present(url, activity, eventProcessor)` in the MobileBuyIntegration samples `CartViewModel` to trigger a delayed second present call.

```kotlin
Handler(Looper.getMainLooper()).postDelayed({
     ShopifyCheckoutSheetKit.present(url, activity, eventProcessor)
}, 500)
```

Repeat on main and on this branch.

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [x] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [x] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
