### PR TITLE
Disable recovery flow for multipass urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.2 October 15 2024
+
+- Prevent entering recovery mode for single-use multipass URLs.
+
 ## 3.1.1 October 2, 2024
 
 - Ensure that cached WebView instances don't have existing parents before trying to add them to their container.

--- a/README.md
+++ b/README.md
@@ -450,6 +450,10 @@ and initialize a buyer-aware checkout session.
 > the above JSON omits useful customer attributes that should be provided where possible and
 > encryption and signing should be done server-side to ensure Multipass keys are kept secret.
 
+> [!NOTE]
+> Multipass errors are not "recoverable" (See [Error Handling](#error-handling)) due to their one-time nature. Failed requests containing multipass URLs
+> will require re-generating new tokens.
+
 #### Shop Pay
 
 To initialize accelerated Shop Pay checkout, the cart can set a

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ your project:
 #### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.1.1"
+implementation "com.shopify:checkout-sheet-kit:3.1.2"
 ```
 
 #### Maven
@@ -33,7 +33,7 @@ implementation "com.shopify:checkout-sheet-kit:3.1.1"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.1.1</version>
+   <version>3.1.2</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.1.1")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.1.2")
 
 ext {
     app_compat_version = '1.6.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -151,9 +151,8 @@ internal class CheckoutDialog(
 
     internal fun closeCheckoutDialogWithError(exception: CheckoutException) {
         checkoutEventProcessor.onCheckoutFailed(exception)
-
-        val isOneTimeUseURL = this.checkoutUrl.contains("multipass")
-        if (!isOneTimeUseURL && ShopifyCheckoutSheetKit.configuration.errorRecovery.shouldRecoverFromError(exception)) {
+        if (!this.checkoutUrl.isOneTimeUse() &&
+            ShopifyCheckoutSheetKit.configuration.errorRecovery.shouldRecoverFromError(exception)) {
             attemptToRecoverFromError(exception)
         } else {
             dismiss()

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -151,7 +151,9 @@ internal class CheckoutDialog(
 
     internal fun closeCheckoutDialogWithError(exception: CheckoutException) {
         checkoutEventProcessor.onCheckoutFailed(exception)
-        if (ShopifyCheckoutSheetKit.configuration.errorRecovery.shouldRecoverFromError(exception)) {
+
+        val isOneTimeUseURL = this.checkoutUrl.contains("multipass")
+        if (!isOneTimeUseURL && ShopifyCheckoutSheetKit.configuration.errorRecovery.shouldRecoverFromError(exception)) {
             attemptToRecoverFromError(exception)
         } else {
             dismiss()

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -162,21 +162,9 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
 
             return trimmedUri.build()
         }
-
-        private fun Uri?.isWebLink(): Boolean = setOf(Scheme.HTTP, Scheme.HTTPS).contains(this?.scheme)
-        private fun Uri?.isMailtoLink(): Boolean = this?.scheme == Scheme.MAILTO
-        private fun Uri?.isTelLink(): Boolean = this?.scheme == Scheme.TEL
-        private fun Uri?.isContactLink(): Boolean = this.isMailtoLink() || this.isTelLink()
     }
 
     companion object {
-        private object Scheme {
-            const val HTTP = "http"
-            const val HTTPS = "https"
-            const val TEL = "tel"
-            const val MAILTO = "mailto"
-        }
-
         private const val OPEN_EXTERNALLY_PARAM = "open_externally"
         private const val JAVASCRIPT_INTERFACE_NAME = "android"
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/UriExtensions.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/UriExtensions.kt
@@ -1,0 +1,38 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkoutsheetkit
+
+import android.net.Uri
+
+internal fun Uri?.isWebLink(): Boolean = setOf(Scheme.HTTP, Scheme.HTTPS).contains(this?.scheme)
+internal fun Uri?.isMailtoLink(): Boolean = this?.scheme == Scheme.MAILTO
+internal fun Uri?.isTelLink(): Boolean = this?.scheme == Scheme.TEL
+internal fun Uri?.isContactLink(): Boolean = this.isMailtoLink() || this.isTelLink()
+internal fun String.isOneTimeUse(): Boolean = this.contains("login/multipass")
+
+internal object Scheme {
+    const val HTTP = "http"
+    const val HTTPS = "https"
+    const val TEL = "tel"
+    const val MAILTO = "mailto"
+}

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/UriExtensions.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/UriExtensions.kt
@@ -28,7 +28,7 @@ internal fun Uri?.isWebLink(): Boolean = setOf(Scheme.HTTP, Scheme.HTTPS).contai
 internal fun Uri?.isMailtoLink(): Boolean = this?.scheme == Scheme.MAILTO
 internal fun Uri?.isTelLink(): Boolean = this?.scheme == Scheme.TEL
 internal fun Uri?.isContactLink(): Boolean = this.isMailtoLink() || this.isTelLink()
-internal fun String.isOneTimeUse(): Boolean = this.contains("login/multipass")
+internal fun String.isOneTimeUse(): Boolean = this.contains("multipass")
 
 internal object Scheme {
     const val HTTP = "http"

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
@@ -192,7 +192,7 @@ class CheckoutDialogTest {
     @Test
     fun `does not call attemptToRecoverFromError if closeCheckoutDialogWithError is called when url contains multipass`() {
         val mockEventProcessor = mock<DefaultCheckoutEventProcessor>()
-        ShopifyCheckoutSheetKit.present("https://shopify.com/a/b/c/multipass", activity, mockEventProcessor)
+        ShopifyCheckoutSheetKit.present("https://shopify.com/account/login/multipass", activity, mockEventProcessor)
 
         val checkoutDialog = ShadowDialog.getLatestDialog() as CheckoutDialog
         assertThat(checkoutDialog.containsChildOfType(CheckoutWebView::class.java)).isTrue()

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
@@ -190,6 +190,24 @@ class CheckoutDialogTest {
     }
 
     @Test
+    fun `does not call attemptToRecoverFromError if closeCheckoutDialogWithError is called when url contains multipass`() {
+        val mockEventProcessor = mock<DefaultCheckoutEventProcessor>()
+        ShopifyCheckoutSheetKit.present("https://shopify.com/a/b/c/multipass", activity, mockEventProcessor)
+
+        val checkoutDialog = ShadowDialog.getLatestDialog() as CheckoutDialog
+        assertThat(checkoutDialog.containsChildOfType(CheckoutWebView::class.java)).isTrue()
+
+        checkoutDialog.closeCheckoutDialogWithError(checkoutException(isRecoverable = true))
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        // attemptToRecoverFromError creates a FallbackWebView and removes the CheckoutWebView
+        assertThat(checkoutDialog.containsChildOfType(FallbackWebView::class.java)).isFalse()
+        assertThat(checkoutDialog.containsChildOfType(CheckoutWebView::class.java)).isFalse()
+        verify(mockEventProcessor, never()).onCheckoutCanceled()
+        verify(mockEventProcessor).onCheckoutFailed(any())
+    }
+
+    @Test
     fun `can disable fallback behaviour via shouldRecoverFromError`() {
         val mockEventProcessor = mock<DefaultCheckoutEventProcessor>()
         ShopifyCheckoutSheetKit.configure {


### PR DESCRIPTION
### What changes are you making?

Recovery reloads the provided checkout URL in a simplified WebView. This is incompatible with single-use multipass URLs.

This PR prevents entering the recovery flow for multipass URLs.

### How to test

Open a multipass checkout
Force an error
Ensure checkout does not try to recover 

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [x] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [x] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
