### PR TITLE
Open deep links externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 3.1.2 October 15 2024
+## 3.2.0 October 18 2024
 
 - Prevent entering recovery mode for single-use multipass URLs.
 - Add invalidate() function to interface to allow invalidating preloaded checkouts when necessary.
+- Open deep links externally
 
 ## 3.1.1 October 2, 2024
 

--- a/README.md
+++ b/README.md
@@ -253,10 +253,13 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
         // - deep link (e.g. myapp://checkout)
         // and is being directed outside the application.
 
-        // Note: to support deep links on Android 11+ using the `DefaultCheckoutEventProcessor`, the client app should declare [queries](https://developer.android.com/guide/topics/manifest/queries-element) in its manifest.
-        // See the MobileBuyIntegration sample's [manifest](samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml) for an example.
-        // If no package is found to deal with the link, the processor will log a warning
-        //`Unrecognized scheme for link clicked in checkout` along with the uri.
+        // Note: to support deep links on Android 11+ using the `DefaultCheckoutEventProcessor`,
+        // the client app should declare queries in its manifest declaring which apps it should interact with.
+        // See the MobileBuyIntegration sample's manifest for an example.
+        // Queries reference - https://developer.android.com/guide/topics/manifest/queries-element
+
+        // If no app is found to deal with the link, the processor will log a warning:
+        // `Unrecognized scheme for link clicked in checkout` along with the uri.
     }
 
     override fun onWebPixelEvent(event: PixelEvent) {

--- a/README.md
+++ b/README.md
@@ -253,8 +253,10 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
         // - deep link (e.g. myapp://checkout)
         // and is being directed outside the application.
 
-        // Note: to support deep links, the client app should declare [queries](https://developer.android.com/guide/topics/manifest/queries-element) in its manifest.
+        // Note: to support deep links on Android 11+ using the `DefaultCheckoutEventProcessor`, the client app should declare [queries](https://developer.android.com/guide/topics/manifest/queries-element) in its manifest.
         // See the MobileBuyIntegration sample's [manifest](samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml) for an example.
+        // If no package is found to deal with the link, the processor will log a warning
+        //`Unrecognized scheme for link clicked in checkout` along with the uri.
     }
 
     override fun onWebPixelEvent(event: PixelEvent) {

--- a/README.md
+++ b/README.md
@@ -250,7 +250,11 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
         // - email address (`mailto:`)
         // - telephone number (`tel:`)
         // - web (http:)
+        // - deep link (e.g. myapp://checkout)
         // and is being directed outside the application.
+
+        // Note: to support deep links, the client app should declare [queries](https://developer.android.com/guide/topics/manifest/queries-element) in its manifest.
+        // See the MobileBuyIntegration sample's [manifest](samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml) for an example.
     }
 
     override fun onWebPixelEvent(event: PixelEvent) {

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
         // See the MobileBuyIntegration sample's manifest for an example.
         // Queries reference - https://developer.android.com/guide/topics/manifest/queries-element
 
-        // If no app is found to deal with the link, the processor will log a warning:
+        // If no app can be queried to deal with the link, the processor will log a warning:
         // `Unrecognized scheme for link clicked in checkout` along with the uri.
     }
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
         // and is being directed outside the application.
 
         // Note: to support deep links on Android 11+ using the `DefaultCheckoutEventProcessor`,
-        // the client app should declare queries in its manifest declaring which apps it should interact with.
+        // the client app should add a queries element in its manifest declaring which apps it should interact with.
         // See the MobileBuyIntegration sample's manifest for an example.
         // Queries reference - https://developer.android.com/guide/topics/manifest/queries-element
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
@@ -22,6 +22,7 @@
  */
 package com.shopify.checkoutsheetkit
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -127,7 +128,7 @@ public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
             "tel" -> context.launchPhoneApp(uri.schemeSpecificPart)
             "mailto" -> context.launchEmailApp(uri.schemeSpecificPart)
             "https", "http" -> context.launchBrowser(uri)
-            else -> log.w(TAG, "Unrecognized scheme for link clicked in checkout '$uri'")
+            else -> context.tryLaunchDeepLink(uri)
         }
     }
 
@@ -163,6 +164,17 @@ public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
     private fun Context.launchPhoneApp(phone: String) {
         val intent = Intent(Intent.ACTION_DIAL, Uri.fromParts("tel", phone, null))
         startActivity(intent)
+    }
+
+    @SuppressLint("QueryPermissionsNeeded")
+    private fun Context.tryLaunchDeepLink(uri: Uri) {
+        val intent = Intent(Intent.ACTION_VIEW)
+        intent.data = uri
+        if (context.packageManager.queryIntentActivities(intent, 0).isNotEmpty()) {
+            startActivity(intent)
+        } else {
+            log.w(TAG, "Unrecognized scheme for link clicked in checkout '$uri'")
+        }
     }
 
     private companion object {

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -129,7 +129,11 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
             view: WebView?,
             request: WebResourceRequest?
         ): Boolean {
-            if (request?.hasExternalAnnotation() == true || request?.url?.isContactLink() == true) {
+            if (
+                request?.hasExternalAnnotation() == true ||
+                request?.url?.isContactLink() == true ||
+                request?.url?.isDeepLink() == true
+            ) {
                 checkoutBridge.getEventProcessor().onCheckoutViewLinkClicked(request.trimmedUri())
                 return true
             }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/UriExtensions.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/UriExtensions.kt
@@ -28,6 +28,7 @@ internal fun Uri?.isWebLink(): Boolean = setOf(Scheme.HTTP, Scheme.HTTPS).contai
 internal fun Uri?.isMailtoLink(): Boolean = this?.scheme == Scheme.MAILTO
 internal fun Uri?.isTelLink(): Boolean = this?.scheme == Scheme.TEL
 internal fun Uri?.isContactLink(): Boolean = this.isMailtoLink() || this.isTelLink()
+internal fun Uri?.isDeepLink(): Boolean = this != null && !this.isWebLink() && !this.isContactLink()
 internal fun String.isOneTimeUse(): Boolean = this.contains("multipass")
 
 internal object Scheme {

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
@@ -85,6 +85,18 @@ class CheckoutWebViewClientTest {
     }
 
     @Test
+    fun `overrides url loading to call event processor for deep links`() {
+        val mockRequest = mockWebRequest(Uri.parse("geo:40.712776,-74.005974?q=Statue+of+Liberty"))
+
+        val view = viewWithProcessor(activity)
+        val webViewClient = view.CheckoutWebViewClient()
+        val overridden = webViewClient.shouldOverrideUrlLoading(view, mockRequest)
+
+        assertThat(overridden).isTrue
+        verify(mockEventProcessor).onCheckoutLinkClicked(mockRequest.url)
+    }
+
+    @Test
     fun `does not override url loading to call event processor for web links`() {
         val mockRequest = mockWebRequest(Uri.parse("https://checkout-sdk.myshopify.com"))
 

--- a/samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml
+++ b/samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml
@@ -13,6 +13,20 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
+    <queries>
+        <!-- for supporting deep links to the maps app -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="geo" />
+        </intent>
+
+        <!-- for supporting deep links to the messaging app -->
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="sms" />
+        </intent>
+    </queries>
+
     <application
         android:name=".MobileBuyIntegration"
         android:allowBackup="true"


### PR DESCRIPTION
### What changes are you making?

Open deep links externally, similar to ios here - https://github.com/Shopify/checkout-sheet-kit-swift/pull/227

- When links are clicked, we'll call `onCheckoutLinkClicked()`
- The DefaultCheckoutEventProcessor will try to open the link
- The client app should specified `queries` in its manifest to determine which links/schemes should open.

### How to test

Tested with a couple of links

```html
<a href="geo:40.712776,-74.005974?q=Statue+of+Liberty">
    Statue of Liberty
</a>

<a href="sms:+1234567890?body=Hello%20there!">
    Send SMS
</a>
```

https://github.com/user-attachments/assets/41375d89-3d20-4c18-aa30-b922e5e266de

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
