### PR TITLE
Add cart quantity controls and expose preload cache invalidate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.1.2 October 15 2024
 
 - Prevent entering recovery mode for single-use multipass URLs.
+- Add invalidate() function to interface to allow invalidating preloaded checkouts when necessary.
 
 ## 3.1.1 October 2, 2024
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ ShopifyCheckoutSheetKit.configure {
 ShopifyCheckoutSheetKit.preload(checkoutUrl) // no-op
 ```
 
+#### Invalidation
+
+To invalidate a preloaded checkout, call `ShopifyCheckoutSheetKit.invalidate()`. This function will be a no-op if no checkout is preloaded.
+
+You may wish to do this if the buyer changes shortly before entering checkout, e.g. by changing cart quantity on a cart view.
+
 #### Lifecycle management for preloaded checkout
 
 Preloading renders a checkout in a background webview, which is brought to foreground when `ShopifyCheckoutSheetKit.present()` is called. The content of preloaded checkout reflects the state of the cart when `preload()` was initially called. If the cart is mutated after `preload()` is called, the application is responsible for invalidating the preloaded checkout to ensure that up-to-date checkout content is displayed to the buyer:

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
@@ -69,6 +69,14 @@ public object ShopifyCheckoutSheetKit {
     }
 
     /**
+     * Invalidate WebViews cached due to preload calls
+     */
+    @JvmStatic
+    public fun invalidate() {
+        CheckoutWebView.markCacheEntryStale()
+    }
+
+    /**
      * Preloads a Shopify checkout in the background.
      *
      * Preloading checkout is fully optional, but allows reducing the time taken between calling

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewContainerTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewContainerTest.kt
@@ -34,7 +34,6 @@ import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
-import kotlin.time.Duration.Companion.minutes
 
 @RunWith(RobolectricTestRunner::class)
 class CheckoutWebViewContainerTest {

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKitTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKitTest.kt
@@ -77,6 +77,25 @@ class ShopifyCheckoutSheetKitTest {
     }
 
     @Test
+    fun `invalidate marks cache entry as stale meaning it will not be used when presenting`() {
+        Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+            withPreloadingEnabled {
+                val url = "https://shopify.dev"
+                ShopifyCheckoutSheetKit.preload(url, activityController.get())
+                ShadowLooper.shadowMainLooper().runToEndOfTasks()
+
+                ShopifyCheckoutSheetKit.invalidate()
+                ShadowLooper.shadowMainLooper().runToEndOfTasks()
+
+                assertThat(CheckoutWebView.cacheEntry).isNotNull()
+                val entry = CheckoutWebView.cacheEntry!!
+
+                assertThat(entry.isStale).isTrue()
+            }
+        }
+    }
+
+    @Test
     fun `preload caches a new WebView, loads the URL, and destroys old view if cache is not empty`() {
         Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
             withPreloadingEnabled {

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/CartItem.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/CartItem.kt
@@ -27,15 +27,26 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Card
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 @Composable
-fun CartItem(title: String, vendor: String, quantity: Int, modifier: Modifier) {
+fun CartItem(
+    loading: Boolean,
+    title: String,
+    vendor: String,
+    quantity: Int,
+    setQuantity: (Int) -> Unit,
+    modifier: Modifier
+) {
     Card(
         elevation = 0.dp,
         modifier = modifier
@@ -44,12 +55,31 @@ fun CartItem(title: String, vendor: String, quantity: Int, modifier: Modifier) {
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth(.9f).padding(10.dp),
         ) {
-            Column(Modifier.weight(.9f)) {
+            Column(Modifier.weight(.9f).align(Alignment.CenterVertically)) {
                 Text(title)
                 Text(vendor, fontSize = 10.sp)
             }
 
-            Text("$quantity")
+            Row {
+                TextButton(
+                    modifier = Modifier.width(40.dp),
+                    enabled = !loading,
+                    onClick = { setQuantity(quantity - 1) }) {
+                    Text("-")
+                }
+                Text(
+                    text = "$quantity",
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.align(Alignment.CenterVertically)
+                )
+                TextButton(
+                    modifier = Modifier.width(40.dp),
+                    enabled = !loading,
+                    onClick = { setQuantity(quantity + 1) }
+                ) {
+                    Text("+")
+                }
+            }
         }
     }
 }

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/CartState.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/CartState.kt
@@ -38,7 +38,7 @@ sealed class CartState {
 
 }
 
-data class CartLine(val title: String, val vendor: String, val quantity: Int)
+data class CartLine(val id: ID, val title: String, val vendor: String, val quantity: Int)
 data class CartTotals(val totalQuantity: Int, val totalAmount: Amount)
 data class Amount(val currency: String, val price: Double)
 

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/client/StorefrontClient.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/client/StorefrontClient.kt
@@ -30,6 +30,7 @@ import com.shopify.buy3.Storefront
 import com.shopify.buy3.Storefront.CartBuyerIdentityInput
 import com.shopify.buy3.Storefront.CartInput
 import com.shopify.buy3.Storefront.CartLineInput
+import com.shopify.buy3.Storefront.CartLineUpdateInput
 import com.shopify.buy3.Storefront.CartQuery
 import com.shopify.buy3.Storefront.MutationQuery
 import com.shopify.buy3.Storefront.ProductVariantQuery
@@ -71,6 +72,29 @@ class StorefrontClient(private val client: GraphClient) {
             }
         }
         executeQuery(query, successCallback, failureCallback)
+    }
+
+    fun cartLinesUpdate(
+        cartId: ID,
+        lineItemID: ID,
+        quantity: Int,
+        successCallback: (GraphResponse<Storefront.Mutation>) -> Unit,
+        failureCallback: ((GraphError) -> Unit)? = {},
+    ) {
+        val lineUpdateInput = CartLineUpdateInput(lineItemID).setQuantity(quantity)
+
+        val mutation =  Storefront.mutation { mutation ->
+            mutation.cartLinesUpdate(
+                cartId,
+                listOf(lineUpdateInput)
+            ) { cartLinesUpdate ->
+                cartLinesUpdate.cart { cartQuery ->
+                    cartQueryFragment(cartQuery)
+                }
+            }
+        }
+
+        executeMutation(mutation, successCallback, failureCallback)
     }
 
     fun createCart(
@@ -129,6 +153,7 @@ class StorefrontClient(private val client: GraphClient) {
             }
             .lines({ it.first(250) }) { lineQuery ->
                 lineQuery.nodes { line ->
+                    line.id()
                     line.quantity()
                     line.merchandise { merchandise ->
                         merchandise.onProductVariant { variant ->

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/product/ProductView.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/product/ProductView.kt
@@ -22,7 +22,6 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.product
 
-import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -39,11 +38,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.AppBarState
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.cart.CartViewModel
-import com.shopify.checkoutsheetkit.ShopifyCheckoutSheetKit
 import org.koin.androidx.compose.koinViewModel
 
 @Composable


### PR DESCRIPTION
### What changes are you making?

Exposes an invalidate function that clients can call to invalidate the preload cache.

Adds quantity controls to the cart page in the MobileBuyIntegration sample app.  Calls invalidate when they're used.

https://github.com/user-attachments/assets/1d679d96-d462-4779-bf0c-3dfcf473ad85

### How to test

Start it up and test it out

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
