### PR TITLE
Implement product paging and add query cache

### DIFF
--- a/samples/MobileBuyIntegration/app/build.gradle
+++ b/samples/MobileBuyIntegration/app/build.gradle
@@ -1,5 +1,3 @@
-import com.android.build.api.variant.BuildConfigField
-
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
@@ -93,6 +91,7 @@ dependencies {
     implementation "io.insert-koin:koin-androidx-compose:$koin_android_compose_version"
     implementation "androidx.room:room-runtime:$room_version"
     implementation 'androidx.compose.material3:material3-android:1.3.1'
+    implementation 'androidx.paging:paging-compose-android:3.3.4'
     annotationProcessor "androidx.room:room-compiler:$room_version"
     ksp "androidx.room:room-compiler:$room_version"
 

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/MoneyFormatter.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/MoneyFormatter.kt
@@ -22,9 +22,15 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.common
 
+import android.content.Context
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.R
 import java.util.Locale
 
-fun toDisplayText(currencyCode: String, price: Double, locale: Locale, includeSuffix: Boolean): String {
+fun toDisplayText(context: Context, currencyCode: String, price: Double, locale: Locale, includeSuffix: Boolean): String {
+    if (price == 0.0) {
+        return context.resources.getString(R.string.free)
+    }
+
     val displayText = "${currencyCode.toSymbol()}${price.toTwoDecimalString(locale)}"
     if (includeSuffix) {
         return "$displayText $currencyCode"

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/client/ProductPagingSource.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/client/ProductPagingSource.kt
@@ -1,3 +1,25 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.common.client
 
 import androidx.paging.PagingSource

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/client/ProductPagingSource.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/client/ProductPagingSource.kt
@@ -1,0 +1,85 @@
+package com.shopify.checkout_sdk_mobile_buy_integration_sample.common.client
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.shopify.buy3.Storefront
+import com.shopify.buy3.Storefront.Product
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.products.product.UIProduct
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.products.product.UIProductImage
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.products.product.UIProductVariant
+import timber.log.Timber
+import kotlin.coroutines.suspendCoroutine
+
+class ProductPagingSource(
+    private val backend: StorefrontClient,
+) : PagingSource<String, UIProduct>() {
+    override suspend fun load(
+        params: LoadParams<String>
+    ): LoadResult<String, UIProduct> {
+        try {
+            val cursor = params.key
+            Timber.i("Fetching page of ${params.loadSize} products with cursor $cursor")
+            val response = getProducts(params.loadSize, 10, cursor)
+            Timber.i("Fetched products $response")
+            return response
+        } catch (e: Exception) {
+            Timber.e("Error when paging through data $e")
+            return LoadResult.Error(e)
+        }
+    }
+
+    private suspend fun getProducts(numProducts: Int, numVariants: Int, cursor: String?): LoadResult<String, UIProduct> {
+        return suspendCoroutine { continuation ->
+            backend.fetchProducts(numProducts = numProducts, numVariants = numVariants, cursor = cursor, successCallback = { response ->
+                val products = response.data?.products
+                if (products != null) {
+                    continuation.resumeWith(
+                        Result.success(
+                            LoadResult.Page(
+                                data = products.edges.map { it.node.toUIProduct() },
+                                prevKey = null,
+                                nextKey = products.pageInfo.endCursor,
+                            )
+                        )
+                    )
+                } else {
+                    continuation.resumeWith(Result.failure(RuntimeException("Failed to fetch data")))
+                }
+            }, failureCallback = {
+                continuation.resumeWith(Result.failure(RuntimeException("Failed to fetch data")))
+            })
+        }
+    }
+
+    private fun Product.toUIProduct(): UIProduct {
+        val variants = this.variants as Storefront.ProductVariantConnection
+        val firstVariant = variants.nodes.first()
+        val uiProduct = UIProduct(
+            id = id,
+            title = title,
+            vendor = vendor,
+            description = description,
+            image = if (featuredImage == null) UIProductImage() else UIProductImage(
+                width = featuredImage.width,
+                height = featuredImage.height,
+                url = featuredImage.url,
+                altText = featuredImage.altText ?: "Product image",
+            ),
+            variants = mutableListOf(
+                UIProductVariant(
+                    id = firstVariant.id,
+                    price = firstVariant.price.amount,
+                    currencyName = firstVariant.price.currencyCode.name,
+                )
+            )
+        )
+        return uiProduct
+    }
+
+
+    override fun getRefreshKey(state: PagingState<String, UIProduct>): String? {
+        return state.anchorPosition?.let { position ->
+            state.closestPageToPosition(position)?.prevKey
+        }
+    }
+}

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/components/TextComponents.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/components/TextComponents.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -178,6 +179,7 @@ fun MoneyText(
         color = color,
         textAlign = textAlign,
         text = toDisplayText(
+            LocalContext.current,
             currency,
             price,
             locale,

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/components/TextComponents.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/components/TextComponents.kt
@@ -118,6 +118,7 @@ fun Header(
         color = color,
         overflow = TextOverflow.Ellipsis,
         textAlign = textAlign,
+        fontSize = fontSize,
     )
 }
 

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/BottomAppBarWithNavigation.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/navigation/BottomAppBarWithNavigation.kt
@@ -62,7 +62,7 @@ fun BottomAppBarWithNavigation(
                 navController,
                 Screen.Products,
                 ImageVector.vectorResource(R.drawable.product),
-                "Product",
+                "Products",
                 currentScreen,
             )
             NavigationItem(

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/di/AppModule.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/di/AppModule.kt
@@ -23,8 +23,11 @@
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.di
 
 import android.app.Application
+import android.util.LruCache
 import androidx.room.Room
+import com.shopify.buy3.GraphCallResult
 import com.shopify.buy3.GraphClient
+import com.shopify.buy3.Storefront
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.BuildConfig
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.cart.CartViewModel
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.client.StorefrontClient
@@ -65,6 +68,11 @@ val appModules = module {
             accessToken = BuildConfig.storefrontAccessToken,
             shopDomain = BuildConfig.storefrontDomain
         )
+    }
+
+    single {
+        val maxEntries = 100
+        LruCache<String, GraphCallResult.Success<Storefront.QueryRoot>>(maxEntries)
     }
 
     single {

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogOverview.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogOverview.kt
@@ -22,16 +22,18 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.logs
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.components.BodySmall
 
 @Composable
@@ -48,10 +50,11 @@ fun LogOverview(log: PrettyLog, onClick: () -> Unit, modifier: Modifier) {
 
         TextButton(
             onClick,
-            Modifier
+            contentPadding = PaddingValues(0.dp),
+            modifier = Modifier
                 .weight(Logs.MESSAGE_COLUMN_WEIGHT)
                 .fillMaxWidth()
-                .wrapContentHeight()
+                .height(28.dp)
         ) {
             BodySmall(
                 text = log.message,

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogOverviewHeader.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogOverviewHeader.kt
@@ -23,6 +23,7 @@
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.logs
 
 import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.components.Header3
@@ -30,7 +31,15 @@ import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.components.
 @Composable
 fun LogOverviewHeader(modifier: Modifier) {
     Row(modifier) {
-        Header3(text = "Date", modifier = Modifier.weight(Logs.DATE_COLUMN_WEIGHT))
-        Header3(text = "Type", modifier = Modifier.weight(Logs.MESSAGE_COLUMN_WEIGHT))
+        Header3(
+            text = "Date",
+            fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+            modifier = Modifier.weight(Logs.DATE_COLUMN_WEIGHT),
+        )
+        Header3(
+            text = "Type",
+            fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+            modifier = Modifier.weight(Logs.MESSAGE_COLUMN_WEIGHT),
+        )
     }
 }

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogsView.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/logs/LogsView.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.R
@@ -76,10 +77,13 @@ fun LogsView(logsViewModel: LogsViewModel) {
                     .padding(horizontal = horizontalPadding, vertical = verticalPadding)
             ) {
 
-                Button({
+                Button(shape = RectangleShape, onClick = {
                     logsViewModel.clear()
                 }) {
-                    BodyMedium(text = stringResource(id = R.string.delete_logs))
+                    BodyMedium(
+                        text = stringResource(id = R.string.delete_logs),
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
                 }
 
                 LazyColumn(Modifier.fillMaxSize()) {
@@ -98,7 +102,7 @@ fun LogsView(logsViewModel: LogsViewModel) {
                                 .background(
                                     if (index % 2 == 0) MaterialTheme.colorScheme.surface else MaterialTheme.colorScheme.background
                                 )
-                                .padding(horizontal = 8.dp),
+                                .padding(horizontal = 8.dp, vertical = 4.dp),
                             onClick = {
                                 logDetails.value = line
                                 logDetailsDialogOpen.value = true

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/products/product/AddToCartButton.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/products/product/AddToCartButton.kt
@@ -54,7 +54,6 @@ fun AddToCartButton(
             onClick = onClick,
             border = BorderStroke(1.dp, MaterialTheme.colorScheme.onBackground),
             shape = RectangleShape
-
         ) {
             Box {
                 Header3(

--- a/samples/MobileBuyIntegration/app/src/main/res/values/strings.xml
+++ b/samples/MobileBuyIntegration/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="color_scheme_web" translatable="false">Web</string>
     <string name="color_scheme_automatic" translatable="false">Automatic</string>
     <string name="preloading_note" translatable="false">NOTE: If preloading is enabled, color scheme changes may not be applied unless the cart is preloaded again.</string>
-    <string name="sdk_version" translatable="false">SDK version</string>
+    <string name="sdk_version" translatable="false">Checkout Sheet Kit version</string>
     <string name="sample_app_version" translatable="false">Sample app version</string>
     <string name="view_logs" translatable="false">View logs</string>
     <string name="delete_logs" translatable="false">Delete logs</string>
@@ -39,4 +39,5 @@
     <string name="cart_empty" translatable="false">Your cart is empty</string>
     <string name="cart_emtpy_description" translatable="false">Add products while you shop, so they\'ll be ready for checkout later.</string>
     <string name="cart_trash_content_description" translatable="false">Delete line item</string>
+    <string name="free" translatable="false">Free</string>
 </resources>


### PR DESCRIPTION
### What changes are you making?

Adds pagination on the products view, for stores with a large number of products
Adds a basic in-memory graphQL query cache to prevent repeatedly making requests for the same data on page nav

### How to test

Run it against the checkout-sdk store.

Network inspector can be used for checking requests, but we also log when we fetch and return cached entries.
Pagination also logs when it's making requests

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
