### PR TITLE
Allow clients to handle onGeolocationPermissionsShowPrompt() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.0 December 4, 2024
+
+- Expose `onGeolocationPermissionsShowPrompt()` and `onGeolocationPermissionsHidePrompt()`, allowing them to be implemented by clients to allow customers to use `Use my location` to find nearby pickup points.
+
 ## 3.2.2 November 15 2024
 
 - Updates the proguard rules for the library to prevent minification of essential classes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.3.0 December 4, 2024
 
-- Expose `onGeolocationPermissionsShowPrompt()` and `onGeolocationPermissionsHidePrompt()`, allowing them to be implemented by clients to allow customers to use `Use my location` to find nearby pickup points.
+- Expose [onGeolocationPermissionsShowPrompt()](<https://developer.android.com/reference/android/webkit/WebChromeClient#onGeolocationPermissionsShowPrompt(java.lang.String,%20android.webkit.GeolocationPermissions.Callback)>) and [onGeolocationPermissionsHidePrompt()](<https://developer.android.com/reference/android/webkit/WebChromeClient#onGeolocationPermissionsHidePrompt()>), allowing them to be implemented so customers can use the `Use my location` functionality to find nearby pickup points.
 
 ## 3.2.2 November 15 2024
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ your project:
 #### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.2.2"
+implementation "com.shopify:checkout-sheet-kit:3.3.0"
 ```
 
 #### Maven
@@ -33,7 +33,7 @@ implementation "com.shopify:checkout-sheet-kit:3.2.2"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.2.2</version>
+   <version>3.3.0</version>
 </dependency>
 ```
 
@@ -275,6 +275,17 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
         // Called to tell the client to show a file chooser. This is called to handle HTML forms with 'file' input type,
         // in response to the user pressing the "Select File" button.
         // To cancel the request, call filePathCallback.onReceiveValue(null) and return true.
+    }
+
+
+    override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {
+        // Called to tell the client to show a geolocation permissions prompt as a geolocation permissions
+        // request has been made.
+        // Invoked for example if a customer uses `Use my location` for pickup points
+    }
+
+       override fun onGeolocationPermissionsHidePrompt() {
+        // Called to tell the client to hide the geolocation permissions prompt, e.g. as the request has been cancelled
     }
 
     override fun onPermissionRequest(permissionRequest: PermissionRequest) {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.2.2")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.3.0")
 
 ext {
     app_compat_version = '1.6.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -33,6 +33,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.webkit.GeolocationPermissions
 import android.webkit.PermissionRequest
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.ValueCallback
@@ -70,6 +71,11 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
                 super.onProgressChanged(view, newProgress)
                 getEventProcessor().updateProgressBar(newProgress)
             }
+
+            override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {
+                getEventProcessor().onGeolocationPermissionsShowPrompt(origin, callback)
+            }
+
             override fun onPermissionRequest(request: PermissionRequest) {
                 getEventProcessor().onPermissionRequest(request)
             }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -76,6 +76,10 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
                 getEventProcessor().onGeolocationPermissionsShowPrompt(origin, callback)
             }
 
+            override fun onGeolocationPermissionsHidePrompt() {
+                getEventProcessor().onGeolocationPermissionsHidePrompt()
+            }
+
             override fun onPermissionRequest(request: PermissionRequest) {
                 getEventProcessor().onPermissionRequest(request)
             }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
@@ -26,6 +26,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.webkit.GeolocationPermissions
 import android.webkit.PermissionRequest
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
@@ -83,6 +84,12 @@ public interface CheckoutEventProcessor {
         filePathCallback: ValueCallback<Array<Uri>>,
         fileChooserParams: WebChromeClient.FileChooserParams,
     ): Boolean
+
+    /**
+     * Called when the client should show a location permissions prompt. For example when using 'Use my location' for
+     * pickup points in checkout
+     */
+    public fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback)
 }
 
 internal class NoopEventProcessor : CheckoutEventProcessor {
@@ -110,6 +117,9 @@ internal class NoopEventProcessor : CheckoutEventProcessor {
     }
 
     override fun onPermissionRequest(permissionRequest: PermissionRequest) {/* noop */
+    }
+
+    override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {/* noop */
     }
 }
 
@@ -146,6 +156,10 @@ public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
         fileChooserParams: WebChromeClient.FileChooserParams,
     ): Boolean {
         return false
+    }
+
+    override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {
+        // no-op override to implement
     }
 
     private fun Context.launchEmailApp(to: String) {

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
@@ -90,6 +90,11 @@ public interface CheckoutEventProcessor {
      * pickup points in checkout
      */
     public fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback)
+
+    /**
+     * Called when the client should hide the location permissions prompt, e.g. if th request is cancelled
+     */
+    public fun onGeolocationPermissionsHidePrompt()
 }
 
 internal class NoopEventProcessor : CheckoutEventProcessor {
@@ -120,6 +125,9 @@ internal class NoopEventProcessor : CheckoutEventProcessor {
     }
 
     override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {/* noop */
+    }
+
+    override fun onGeolocationPermissionsHidePrompt() {/* noop */
     }
 }
 
@@ -159,6 +167,10 @@ public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
     }
 
     override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {
+        // no-op override to implement
+    }
+
+    override fun onGeolocationPermissionsHidePrompt() {
         // no-op override to implement
     }
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
@@ -27,6 +27,7 @@ import android.os.Handler
 import android.os.Looper
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
+import android.webkit.GeolocationPermissions
 import android.webkit.PermissionRequest
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient.FileChooserParams
@@ -64,6 +65,10 @@ internal class CheckoutWebViewEventProcessor(
         onMainThread {
             closeCheckoutDialogWithError(error)
         }
+    }
+
+    fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {
+        return eventProcessor.onGeolocationPermissionsShowPrompt(origin, callback)
     }
 
     fun onShowFileChooser(

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
@@ -71,6 +71,10 @@ internal class CheckoutWebViewEventProcessor(
         return eventProcessor.onGeolocationPermissionsShowPrompt(origin, callback)
     }
 
+    fun onGeolocationPermissionsHidePrompt() {
+        return eventProcessor.onGeolocationPermissionsHidePrompt()
+    }
+
     fun onShowFileChooser(
         webView: WebView,
         filePathCallback: ValueCallback<Array<Uri>>,

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -27,6 +27,7 @@ import android.net.Uri
 import android.os.Looper
 import android.view.View.VISIBLE
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.webkit.GeolocationPermissions
 import android.webkit.PermissionRequest
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient.FileChooserParams
@@ -270,6 +271,22 @@ class CheckoutWebViewTest {
         shadow.webChromeClient.onShowFileChooser(view, filePathCallback, fileChooserParams)
 
         verify(webViewEventProcessor).onShowFileChooser(view, filePathCallback, fileChooserParams)
+    }
+
+    @Test
+    fun `calls processors onGeolocationPermissionsShowPrompt when called on webChromeClient`() {
+        val view = CheckoutWebView.cacheableCheckoutView(URL, activity)
+        val webViewEventProcessor = mock<CheckoutWebViewEventProcessor>()
+        view.setEventProcessor(webViewEventProcessor)
+
+        val shadow = shadowOf(view)
+
+        val callback = mock<GeolocationPermissions.Callback>()
+        val origin = "origin"
+
+        shadow.webChromeClient.onGeolocationPermissionsShowPrompt(origin, callback)
+
+        verify(webViewEventProcessor).onGeolocationPermissionsShowPrompt(origin, callback)
     }
 
     @Test

--- a/samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml
+++ b/samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml
@@ -7,6 +7,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- Optional: Allow querying location for pickup points if enabled -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <!-- Optional: Example permissions required for certain payment methods provided via 3rd party apps -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/MainActivity.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/MainActivity.kt
@@ -116,7 +116,7 @@ class MainActivity : ComponentActivity() {
             // Permission already granted, invoke callback immediately
             callback(origin, true, true)
         } else {
-            //  Permissions not yet granted, request permission before invoking callback
+            // Permission not yet granted, request permission before invoking callback
             geolocationPermissionCallback = callback
             geolocationOrigin = origin
             geolocationLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/MainActivity.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/MainActivity.kt
@@ -56,7 +56,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         // Allow debugging the WebView via chrome://inspect
-        setWebContentsDebuggingEnabled(true)
+        setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
 
         // Setup logging in debug build
         if (BuildConfig.DEBUG) {

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/MobileBuyEventProcessor.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/MobileBuyEventProcessor.kt
@@ -24,6 +24,7 @@ package com.shopify.checkout_sdk_mobile_buy_integration_sample.common
 
 import android.content.Context
 import android.net.Uri
+import android.webkit.GeolocationPermissions
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
@@ -53,7 +54,7 @@ class MobileBuyEventProcessor(
     private val navController: NavController,
     private val logger: Logger,
     private val context: Context
-): DefaultCheckoutEventProcessor(context) {
+) : DefaultCheckoutEventProcessor(context) {
     override fun onCheckoutCompleted(checkoutCompletedEvent: CheckoutCompletedEvent) {
         logger.log(checkoutCompletedEvent)
 
@@ -81,6 +82,10 @@ class MobileBuyEventProcessor(
     override fun onCheckoutCanceled() {
         // optionally respond to checkout being canceled/closed
         logger.log("Checkout canceled")
+    }
+
+    override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {
+        return (context as MainActivity).onGeolocationPermissionsShowPrompt(origin, callback)
     }
 
     override fun onShowFileChooser(


### PR DESCRIPTION
### What changes are you making?

Allow clients to implement onGeolocationPermissionsShowPrompt() for dealing with use my location in the pickup points part of checkout (if enabled).

### How to test

Recorded an example here:

https://github.com/user-attachments/assets/44abc899-fc40-4da3-8cb6-17868c54c7f3

N.b. it says no locations found

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [x] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [x] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
