### PR TITLE
Take api version from the environment

### DIFF
--- a/samples/SimpleCheckout/.env.example
+++ b/samples/SimpleCheckout/.env.example
@@ -1,2 +1,3 @@
 STOREFRONT_DOMAIN=<yourdomainhere.myshopify.com>
-STOREFRONT_ACCESS_TOKEN=<storefront access token>
+STOREFRONT_ACCESS_TOKEN=<Storefront API access token>
+STOREFRONT_API_VERSION=<Storefront API version e.g. 2024-10)

--- a/samples/SimpleCheckout/app/build.gradle
+++ b/samples/SimpleCheckout/app/build.gradle
@@ -16,6 +16,9 @@ def loadProperties() {
 def properties = loadProperties()
 def storefrontDomain = properties.getProperty("STOREFRONT_DOMAIN")
 def accessToken = properties.getProperty("STOREFRONT_ACCESS_TOKEN")
+def apiVersion = properties.getProperty("STOREFRONT_API_VERSION") ?: "2024-10"
+
+println("api version $apiVersion")
 
 if (!storefrontDomain || !accessToken) {
     println("**** Please add a .env file with STOREFRONT_DOMAIN and STOREFRONT_ACCESS_TOKEN set *****")
@@ -33,7 +36,7 @@ apollo {
         mapScalarToKotlinDouble("Decimal")
 
         introspection {
-            endpointUrl.set("https://$storefrontDomain/api/2024-10/graphql.json")
+            endpointUrl.set("https://$storefrontDomain/api/$apiVersion/graphql.json")
             headers.set(["X-Shopify-Storefront-Access-Token": "$accessToken"])
             schemaFile.set(file("src/main/graphql/schema.graphqls"))
         }

--- a/samples/SimpleCheckout/app/build.gradle
+++ b/samples/SimpleCheckout/app/build.gradle
@@ -18,8 +18,6 @@ def storefrontDomain = properties.getProperty("STOREFRONT_DOMAIN")
 def accessToken = properties.getProperty("STOREFRONT_ACCESS_TOKEN")
 def apiVersion = properties.getProperty("STOREFRONT_API_VERSION") ?: "2024-10"
 
-println("api version $apiVersion")
-
 if (!storefrontDomain || !accessToken) {
     println("**** Please add a .env file with STOREFRONT_DOMAIN and STOREFRONT_ACCESS_TOKEN set *****")
 }


### PR DESCRIPTION
### What changes are you making?

Small tweak to take the Storefront API version from the environment, with a default value

### How to test

- Add a println("apiVersion $apiVersion") to the app/build.gradle
- Set no value for STOREFRONT_API_VERSION in .env
- ./gradlew compileDebugKotlin
- check printed value is 2024-10
- Update value for STOREFRONT_API_VERSION to 2024-07
- ./gradlew compileDebugKotlin
- check printed value is 2024-07

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
