### PR TITLE
[Geolocation] Provide default to Invoke geolocation request by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
 ```
 
 > [!Note]
-> The `DefaultCheckoutEventProcessor` provides default implementations for current and future callback functions (such as `onLinkClicked()`), which can be overridden by clients wanting to change default behavior.
+> The `DefaultCheckoutEventProcessor` provides default implementations for current and future callback functions (such as `onCheckoutLinkClicked()`), which can be overridden by clients wanting to change default behavior.
 
 ### Error handling
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -120,6 +120,10 @@ detekt {
     config.setFrom('detekt.config.yml')
 }
 
+ktlint {
+    disabledRules = ['empty_function_block']
+}
+
 tasks.withType(KotlinCompile).configureEach {
     if (!it.name.contains("Test")) {
         kotlinOptions.freeCompilerArgs += "-Xexplicit-api=strict"

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
@@ -167,7 +167,12 @@ public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
     }
 
     override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {
-        // no-op override to implement
+        // Whether to grant the webview permission to access device location
+        val grant = true;
+        // Whether to retain/remember this permission decision for future requests
+        val retain = true;
+
+        callback.invoke(origin, grant, retain)
     }
 
     override fun onGeolocationPermissionsHidePrompt() {


### PR DESCRIPTION
### What changes are you making?

Introduces a default implementation for the `onGeolocationPermissionsShowPrompt` method to automatically invoke the callback with the origin, granting access to request geolocation permissions and retain across requests.

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
