### PR TITLE
[Geolocation] Provide default implementation for geolocation callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ val processor = object : DefaultCheckoutEventProcessor(activity) {
 ```
 
 > [!Note]
-> The `DefaultCheckoutEventProcessor` provides default implementations for current and future callback functions (such as `onLinkClicked()`), which can be overridden by clients wanting to change default behavior.
+> The `DefaultCheckoutEventProcessor` provides default implementations for current and future callback functions (such as `onCheckoutLinkClicked()`), which can be overridden by clients wanting to change default behavior.
 
 ### Error handling
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
@@ -37,99 +37,111 @@ import com.shopify.checkoutsheetkit.lifecycleevents.CheckoutCompletedEvent
 import com.shopify.checkoutsheetkit.pixelevents.PixelEvent
 
 /**
- * Interface to implement to allow responding to lifecycle events in checkout.
- * We'd strongly recommend extending DefaultCheckoutEventProcessor where possible
+ * Interface to implement to allow responding to lifecycle events in checkout. We'd strongly
+ * recommend extending DefaultCheckoutEventProcessor where possible
  */
 public interface CheckoutEventProcessor {
-    /**
-     * Event representing the successful completion of a checkout.
-     */
+    /** Event representing the successful completion of a checkout. */
     public fun onCheckoutCompleted(checkoutCompletedEvent: CheckoutCompletedEvent)
 
     /**
-     * Event representing an error that occurred during checkout. This can be used to display
-     * error messages for example.
+     * Event representing an error that occurred during checkout. This can be used to display error
+     * messages for example.
      *
-     * @param error - the CheckoutErrorException that occurred
+     * @param error
+     * - the CheckoutErrorException that occurred
      * @see Exception
      */
     public fun onCheckoutFailed(error: CheckoutException)
 
-    /**
-     * Event representing the cancellation/closing of checkout by the buyer
-     */
+    /** Event representing the cancellation/closing of checkout by the buyer */
     public fun onCheckoutCanceled()
 
     /**
      * Event indicating that a link has been clicked within checkout that should be opened outside
-     * of the WebView, e.g. in a system browser or email client. Protocols can be http/https/mailto/tel
+     * of the WebView, e.g. in a system browser or email client. Protocols can be
+     * http/https/mailto/tel
      */
     public fun onCheckoutLinkClicked(uri: Uri)
 
-    /**
-     * A permission has been requested by the web chrome client, e.g. to access the camera
-     */
+    /** A permission has been requested by the web chrome client, e.g. to access the camera */
     public fun onPermissionRequest(permissionRequest: PermissionRequest)
 
     /**
-     * Web Pixel event emitted from checkout, that can be optionally transformed, enhanced (e.g. with user and session identifiers),
-     * and processed
+     * Web Pixel event emitted from checkout, that can be optionally transformed, enhanced (e.g.
+     * with user and session identifiers), and processed
      */
     public fun onWebPixelEvent(event: PixelEvent)
 
     /**
-     * Called when the client should show a file chooser. This is called to handle HTML forms with 'file' input type, in response to the
-     * user pressing the "Select File" button. To cancel the request, call filePathCallback.onReceiveValue(null) and return true.
+     * Called when the client should show a file chooser. This is called to handle HTML forms with
+     * 'file' input type, in response to the user pressing the "Select File" button. To cancel the
+     * request, call filePathCallback.onReceiveValue(null) and return true.
      */
     public fun onShowFileChooser(
-        webView: WebView,
-        filePathCallback: ValueCallback<Array<Uri>>,
-        fileChooserParams: WebChromeClient.FileChooserParams,
+            webView: WebView,
+            filePathCallback: ValueCallback<Array<Uri>>,
+            fileChooserParams: WebChromeClient.FileChooserParams,
     ): Boolean
 
     /**
-     * Called when the client should show a location permissions prompt. For example when using 'Use my location' for
-     * pickup points in checkout
+     * Called when the client should show a location permissions prompt. For example when using 'Use
+     * my location' for pickup points in checkout
      */
-    public fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback)
+    public fun onGeolocationPermissionsShowPrompt(
+            origin: String,
+            callback: GeolocationPermissions.Callback
+    )
 
     /**
-     * Called when the client should hide the location permissions prompt, e.g. if th request is cancelled
+     * Called when the client should hide the location permissions prompt, e.g. if th request is
+     * cancelled
      */
     public fun onGeolocationPermissionsHidePrompt()
 }
 
 internal class NoopEventProcessor : CheckoutEventProcessor {
-    override fun onCheckoutCompleted(checkoutCompletedEvent: CheckoutCompletedEvent) {/* noop */
+    override fun onCheckoutCompleted(checkoutCompletedEvent: CheckoutCompletedEvent) {
+        /* noop */
     }
 
-    override fun onCheckoutFailed(error: CheckoutException) {/* noop */
+    override fun onCheckoutFailed(error: CheckoutException) {
+        /* noop */
     }
 
-    override fun onCheckoutCanceled() {/* noop */
+    override fun onCheckoutCanceled() {
+        /* noop */
     }
 
-    override fun onCheckoutLinkClicked(uri: Uri) {/* noop */
+    override fun onCheckoutLinkClicked(uri: Uri) {
+        /* noop */
     }
 
-    override fun onWebPixelEvent(event: PixelEvent) {/* noop */
+    override fun onWebPixelEvent(event: PixelEvent) {
+        /* noop */
     }
 
     override fun onShowFileChooser(
-        webView: WebView,
-        filePathCallback: ValueCallback<Array<Uri>>,
-        fileChooserParams: WebChromeClient.FileChooserParams,
+            webView: WebView,
+            filePathCallback: ValueCallback<Array<Uri>>,
+            fileChooserParams: WebChromeClient.FileChooserParams,
     ): Boolean {
         return false
     }
 
-    override fun onPermissionRequest(permissionRequest: PermissionRequest) {/* noop */
+    override fun onPermissionRequest(permissionRequest: PermissionRequest) {
+        /* noop */
     }
 
-    override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {/* noop */
+    override fun onGeolocationPermissionsShowPrompt(
+            origin: String,
+            callback: GeolocationPermissions.Callback
+    ) {
+        /* noop */
     }
 
-    override fun onGeolocationPermissionsHidePrompt() {/* noop */
+    override fun onGeolocationPermissionsHidePrompt() {
+        /* noop */
     }
 }
 
@@ -138,15 +150,18 @@ internal class NoopEventProcessor : CheckoutEventProcessor {
  * for handling checkout events and interacting with the Android operating system.
  * @param context from which we will launch intents.
  */
-public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
-    private val context: Context,
-    private val log: LogWrapper = LogWrapper(),
+public abstract class DefaultCheckoutEventProcessor
+@JvmOverloads
+constructor(
+        private val context: Context,
+        private val log: LogWrapper = LogWrapper(),
 ) : CheckoutEventProcessor {
 
-    private val LOCATION_PERMISSIONS: Array<String> = arrayOf(
-        Manifest.permission.ACCESS_FINE_LOCATION,
-        Manifest.permission.ACCESS_COARSE_LOCATION
-    )
+    private val locationPermissions: Array<String> =
+            arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION
+            )
 
     override fun onCheckoutLinkClicked(uri: Uri) {
         when (uri.scheme) {
@@ -166,38 +181,42 @@ public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
     }
 
     override fun onShowFileChooser(
-        webView: WebView,
-        filePathCallback: ValueCallback<Array<Uri>>,
-        fileChooserParams: WebChromeClient.FileChooserParams,
+            webView: WebView,
+            filePathCallback: ValueCallback<Array<Uri>>,
+            fileChooserParams: WebChromeClient.FileChooserParams,
     ): Boolean {
         return false
     }
 
     /**
-     * Called when the webview requests location permissions. For example when using 'Use my location' to locate pickup points.
-     * The default implementation here will check for both manifest and runtime permissions. If both have been granted,
-     * permission will be granted to present the location prompt to the user.
+     * Called when the webview requests location permissions. For example when using 'Use my
+     * location' to locate pickup points. The default implementation here will check for both
+     * manifest and runtime permissions. If both have been granted, permission will be granted to
+     * present the location prompt to the user.
      *
-     * Runtime permissions must be requested by your host app. The Checkout Sheet kit cannot request them on your behalf.
+     * Runtime permissions must be requested by your host app. The Checkout Sheet kit cannot request
+     * them on your behalf.
      */
     override fun onGeolocationPermissionsShowPrompt(
-        origin: String,
-        callback: GeolocationPermissions.Callback
+            origin: String,
+            callback: GeolocationPermissions.Callback
     ) {
         // Check manifest permissions
-        val manifestPermissions = try {
-            context.packageManager
-                .getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
-                .requestedPermissions
-                ?.toSet() ?: emptySet()
-        } catch (e: Exception) {
-            emptySet()
-        }
+        val manifestPermissions =
+                try {
+                    context.packageManager
+                            .getPackageInfo(context.packageName, PackageManager.GET_PERMISSIONS)
+                            .requestedPermissions
+                            ?.toSet()
+                            ?: emptySet()
+                } catch (e: Exception) {
+                    log.e(TAG, "Failed to get package permissions", e)
+                    emptySet()
+                }
 
         // Check if either permission is declared in manifest
-        val hasManifestPermission = LOCATION_PERMISSIONS.any { permission ->
-            manifestPermissions.contains(permission)
-        }
+        val hasManifestPermission =
+                locationPermissions.any { permission -> manifestPermissions.contains(permission) }
 
         if (!hasManifestPermission) {
             callback.invoke(origin, false, false)
@@ -205,9 +224,10 @@ public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
         }
 
         // Check runtime permissions
-        val hasRuntimePermission = LOCATION_PERMISSIONS.any { permission ->
-            context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
-        }
+        val hasRuntimePermission =
+                locationPermissions.any { permission ->
+                    context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+                }
 
         callback.invoke(origin, hasRuntimePermission, hasRuntimePermission)
     }

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/MainActivity.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/MainActivity.kt
@@ -1,18 +1,18 @@
 /*
  * MIT License
- * 
+ *
  * Copyright 2023-present, Shopify Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,9 +25,7 @@ package com.shopify.checkout_sdk_mobile_buy_integration_sample
 import android.Manifest
 import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
-import android.webkit.GeolocationPermissions
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient.FileChooserParams
 import android.webkit.WebView.setWebContentsDebuggingEnabled
@@ -35,7 +33,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.content.ContextCompat
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 
@@ -44,7 +41,8 @@ class MainActivity : ComponentActivity() {
     private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
     private lateinit var showFileChooserLauncher: ActivityResultLauncher<FileChooserParams>
 
-    // State related to file chooser requests (e.g. for using a file chooser/camera for proving identity)
+    // State related to file chooser requests (e.g. for using a file chooser/camera for proving
+    // identity)
     private var filePathCallback: ValueCallback<Array<Uri>>? = null
     private var fileChooserParams: FileChooserParams? = null
 
@@ -63,45 +61,53 @@ class MainActivity : ComponentActivity() {
             Timber.plant(DebugTree())
         }
 
-        setContent {
-            CheckoutSdkApp()
-        }
+        setContent { CheckoutSdkApp() }
 
-        requestPermissionLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
-            val fileChooserParams = this.fileChooserParams
-            if (isGranted && fileChooserParams != null) {
-                this.showFileChooserLauncher.launch(fileChooserParams)
-                this.fileChooserParams = null
-            }
-            // N.B. a file chooser intent (without camera) could be launched here if the permission was denied
-        }
+        requestPermissionLauncher =
+                registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted
+                    ->
+                    val fileChooserParams = this.fileChooserParams
+                    if (isGranted && fileChooserParams != null) {
+                        this.showFileChooserLauncher.launch(fileChooserParams)
+                        this.fileChooserParams = null
+                    }
+                    // N.B. a file chooser intent (without camera) could be launched here if the
+                    // permission was denied
+                }
 
-        showFileChooserLauncher = registerForActivityResult(FileChooserResultContract()) { uri: Uri? ->
-            // invoke the callback with the selected file
-            filePathCallback?.onReceiveValue(if (uri != null) arrayOf(uri) else null)
+        showFileChooserLauncher =
+                registerForActivityResult(FileChooserResultContract()) { uri: Uri? ->
+                    // invoke the callback with the selected file
+                    filePathCallback?.onReceiveValue(if (uri != null) arrayOf(uri) else null)
 
-            // reset fileChooser state
-            filePathCallback = null
-            fileChooserParams = null
-        }
+                    // reset fileChooser state
+                    filePathCallback = null
+                    fileChooserParams = null
+                }
     }
 
     fun requestGeolocationPermission() {
-        val fineLocationGranted = checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
-        val coarseLocationGranted = checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
+        val fineLocationGranted = permissionGranted(Manifest.permission.ACCESS_FINE_LOCATION)
+        val coarseLocationGranted = permissionGranted(Manifest.permission.ACCESS_COARSE_LOCATION)
 
         if (!fineLocationGranted && !coarseLocationGranted) {
             requestPermissions(
-                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION),
+                    arrayOf(
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.ACCESS_COARSE_LOCATION
+                    ),
                     LOCATION_PERMISSION_REQUEST_CODE
             )
         }
     }
 
     // Show a file chooser when prompted by the event processor
-    fun onShowFileChooser(filePathCallback: ValueCallback<Array<Uri>>, fileChooserParams: FileChooserParams): Boolean {
+    fun onShowFileChooser(
+            filePathCallback: ValueCallback<Array<Uri>>,
+            fileChooserParams: FileChooserParams
+    ): Boolean {
         this.filePathCallback = filePathCallback
-        if (permissionAlreadyGranted(Manifest.permission.CAMERA)) {
+        if (permissionGranted(Manifest.permission.CAMERA)) {
             // Permissions already granted, launch chooser immediately
             showFileChooserLauncher.launch(fileChooserParams)
             this.fileChooserParams = null
@@ -113,7 +119,7 @@ class MainActivity : ComponentActivity() {
         return true
     }
 
-    private fun permissionAlreadyGranted(permission: String): Boolean {
-        return ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
+    private fun permissionGranted(permission: String): Boolean {
+        return checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
     }
 }

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/MobileBuyEventProcessor.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/MobileBuyEventProcessor.kt
@@ -85,7 +85,8 @@ class MobileBuyEventProcessor(
     }
 
     override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {
-        return (context as MainActivity).onGeolocationPermissionsShowPrompt(origin, callback)
+        (context as MainActivity).requestGeolocationPermission()
+        super.onGeolocationPermissionsShowPrompt(origin, callback)
     }
 
     override fun onShowFileChooser(


### PR DESCRIPTION
### What changes are you making?

Provides a default implementation for the `onGeolocationPermissionsShowPrompt` lifecycle method, which checks for both manifest and runtime permissions.

This will simplify the implementation in that consumers will only need to care about requesting runtime permissions and calling `super.onGeolocationPermissionsShowPrompt` to let the library handle the rest.

```kt
override fun onGeolocationPermissionsShowPrompt(origin: String, callback: GeolocationPermissions.Callback) {
    (context as MainActivity).requestGeolocationPermission()
     super.onGeolocationPermissionsShowPrompt(origin, callback)
}
```

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
