### PR TITLE
enabling payment request for WebView

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -22,7 +22,7 @@ ext {
 
     androidx_test_version = '1.6.1'
     androidx_junit_ext_version = '1.2.1'
-    androidx_webkit_version = '1.14.0-rc01'
+    androidx_webkit_version = '1.14.0'
 
     junit_version = '4.13.2'
     robolectric_version = '4.11.1'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     //Implementation
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlin_serialization_version"
     implementation "androidx.appcompat:appcompat:$app_compat_version"
-    implementation "androidx.webkit:webkit:1.14.0-beta01"
+    implementation "androidx.webkit:webkit:1.14.0-rc01"
 }
 
 signing {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     //Implementation
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlin_serialization_version"
     implementation "androidx.appcompat:appcompat:$app_compat_version"
-    implementation "androidx.webkit:webkit:1.14.0-alpha01"
+    implementation "androidx.webkit:webkit:1.14.0-beta01"
 }
 
 signing {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -105,6 +105,7 @@ dependencies {
     //Implementation
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlin_serialization_version"
     implementation "androidx.appcompat:appcompat:$app_compat_version"
+    implementation "androidx.webkit:webkit:1.14.0-alpha01"
 }
 
 signing {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -22,6 +22,7 @@ ext {
 
     androidx_test_version = '1.6.1'
     androidx_junit_ext_version = '1.2.1'
+    androidx_webkit_version = '1.14.0-rc01'
 
     junit_version = '4.13.2'
     robolectric_version = '4.11.1'
@@ -105,7 +106,7 @@ dependencies {
     //Implementation
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlin_serialization_version"
     implementation "androidx.appcompat:appcompat:$app_compat_version"
-    implementation "androidx.webkit:webkit:1.14.0-rc01"
+    implementation "androidx.webkit:webkit:$androidx_webkit_version"
 }
 
 signing {

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <queries>
+        <intent>
+            <action android:name="org.chromium.intent.action.PAY"/>
+        </intent>
+        <intent>
+            <action android:name="org.chromium.intent.action.IS_READY_TO_PAY"/>
+        </intent>
+        <intent>
+            <action android:name="org.chromium.intent.action.UPDATE_PAYMENT_DETAILS"/>
+        </intent>
+    </queries>
 
 </manifest>

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -43,6 +43,8 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
 import java.net.HttpURLConnection.HTTP_GONE
 import java.net.HttpURLConnection.HTTP_NOT_FOUND
 
@@ -66,6 +68,12 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
             domStorageEnabled = true
             allowContentAccess = true
         }
+
+        if (WebViewFeature.isFeatureSupported(
+                WebViewFeature.PAYMENT_REQUEST)) {
+            WebSettingsCompat.setPaymentRequestEnabled(settings, true)
+        }
+
         webChromeClient = object: WebChromeClient() {
             override fun onProgressChanged(view: WebView?, newProgress: Int) {
                 super.onProgressChanged(view, newProgress)


### PR DESCRIPTION
### What changes are you making?

This change enables the [Payment Request API for WebView](https://developers.chrome.com/docs/android/payments-in-webviews). This is a requirement for [Google Pay to work](https://developers.google.com/pay/api/android/guides/recipes/using-android-webview) within the WebView the Checkout Sheet Kit uses.

For more details see #92 

### Testing video
https://github.com/user-attachments/assets/9de37aac-c682-4d6a-b137-ff4d90d7ed10

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
