### PR TITLE
add isFirstOrder to OrderCustomer in checkout pixel events

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEvent.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/pixelevents/PixelEvent.kt
@@ -40,8 +40,10 @@ internal class PixelEventWrapper(
 
 @Serializable
 public enum class EventType(public val typeName: String) {
-    @SerialName("standard") STANDARD("standard"),
-    @SerialName("custom") CUSTOM("custom");
+    @SerialName("standard")
+    STANDARD("standard"),
+    @SerialName("custom")
+    CUSTOM("custom");
 
     public companion object {
         public fun fromTypeName(typeName: String?): EventType? {
@@ -87,7 +89,7 @@ public data class StandardPixelEvent(
     public override val type: EventType? = null,
     public val context: Context? = null,
     public val data: StandardPixelEventData? = null,
-): PixelEvent
+) : PixelEvent
 
 @Serializable
 public data class StandardPixelEventData(
@@ -951,6 +953,8 @@ public data class OrderCustomer(
      * The ID of the customer.
      */
     public val id: String? = null,
+
+    public val isFirstOrder: Boolean? = null,
 )
 
 @Serializable
@@ -1056,7 +1060,7 @@ public data class CustomPixelEvent(
     // Clients are expected to define their own type for each custom event, and deserialize from String
     @Serializable(with = JsonObjectAsStringSerializer::class)
     public val customData: String? = null,
-): PixelEvent
+) : PixelEvent
 
 public object JsonObjectAsStringSerializer : KSerializer<String> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("WithCustomDefault", PrimitiveKind.STRING)

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoderTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/pixelevents/PixelEventDecoderTest.kt
@@ -52,7 +52,10 @@ class PixelEventDecoderTest {
             |        "data": {
             |            "checkout": {
             |                "order": {
-            |                    "id": "123"
+            |                    "id": "123",
+            |                    "customer": {
+            |                      "isFirstOrder": null
+            |                    }
             |                }
             |            }
             |        }
@@ -71,6 +74,7 @@ class PixelEventDecoderTest {
         assertThat(checkoutStartedEvent.timestamp).isEqualTo("2023-12-20T16:39:23+0000")
         assertThat(checkoutStartedEvent.id).isEqualTo("sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B")
         assertThat(checkoutStartedEvent.data?.checkout?.order?.id).isEqualTo("123")
+        assertThat(checkoutStartedEvent.data?.checkout?.order?.customer?.isFirstOrder).isNull()
 
         verifyNoInteractions(logWrapper)
     }
@@ -92,7 +96,11 @@ class PixelEventDecoderTest {
             |                   "currencyCode": "USD"
             |                },
             |                "order": {
-            |                    "id": "123"
+            |                    "id": "123",
+            |                    "customer": {
+            |                       "id": "456",
+            |                       "isFirstOrder": true
+            |                    }
             |                }
             |            }
             |        }
@@ -111,6 +119,7 @@ class PixelEventDecoderTest {
         assertThat(checkoutStarted.timestamp).isEqualTo("2023-12-20T16:39:23+0000")
         assertThat(checkoutStarted.id).isEqualTo("sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B")
         assertThat(checkoutStarted.data?.checkout?.order?.id).isEqualTo("123")
+        assertThat(checkoutStarted.data?.checkout?.order?.customer?.isFirstOrder).isTrue()
         assertThat(checkoutStarted.data?.checkout?.totalPrice?.amount).isEqualTo(123.3)
         assertThat(checkoutStarted.data?.checkout?.totalPrice?.currencyCode).isEqualTo("USD")
 


### PR DESCRIPTION
### What changes are you making?

Add `isFirstOrder` to `checkout.order.customer` in checkout pixel events

### How to test

<img width="295" alt="Screenshot 2025-05-09 at 11 47 39" src="https://github.com/user-attachments/assets/36711171-22aa-4cc0-a2a4-13d8de13ff90" />

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
