### PR TITLE
Add support to Partner App Authentication

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -51,6 +51,7 @@ internal class CheckoutDialog(
     private val checkoutUrl: String,
     private val checkoutEventProcessor: CheckoutEventProcessor,
     context: Context,
+    private val checkoutOptions: CheckoutOptions? = null
 ) : Dialog(context) {
 
     fun start(context: ComponentActivity) {
@@ -69,6 +70,7 @@ internal class CheckoutDialog(
         val checkoutWebView = CheckoutWebView.cacheableCheckoutView(
             checkoutUrl,
             context,
+            checkoutOptions = checkoutOptions
         )
 
         checkoutWebView.onResume()
@@ -193,11 +195,13 @@ internal class CheckoutDialog(
         ShopifyCheckoutSheetKit.configuration.errorRecovery.preRecoveryActions(exception, checkoutUrl)
 
         log.d(LOG_TAG, "Adding fallback WebView to container.")
+        val options = checkoutOptions
         addWebViewToContainer(
             ShopifyCheckoutSheetKit.configuration.colorScheme,
             FallbackWebView(context).apply {
+                checkoutOptions = options
                 setEventProcessor(eventProcessor())
-                loadUrl(checkoutUrl)
+                loadCheckoutWithHeader(checkoutUrl)
             }
         )
         return true

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutOptions.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutOptions.kt
@@ -1,0 +1,43 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkoutsheetkit
+
+/**
+ * Configuration options for checkout presentation.
+ */
+public data class CheckoutOptions(
+    /**
+     * App authentication configuration for partner identification.
+     */
+    public val appAuthentication: AppAuthentication? = null
+) {
+    /**
+     * Configuration for partner app authentication.
+     */
+    public data class AppAuthentication(
+        /**
+         * The JWT authentication token.
+         */
+        public val token: String
+    )
+}

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/FallbackWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/FallbackWebView.kt
@@ -35,6 +35,7 @@ internal class FallbackWebView(context: Context, attributeSet: AttributeSet? = n
     override val recoverErrors = false
     override val variant = "standard_recovery"
     override val cspSchema = "noconnect"
+    var checkoutOptions: CheckoutOptions? = null
 
     init {
         log.d(LOG_TAG, "Initializing fallback web view.")
@@ -51,6 +52,19 @@ internal class FallbackWebView(context: Context, attributeSet: AttributeSet? = n
 
     override fun getEventProcessor(): CheckoutWebViewEventProcessor {
         return checkoutEventProcessor
+    }
+
+    fun loadCheckoutWithHeader(url: String) {
+        val headers = mutableMapOf<String, String>()
+
+        // Add app authentication header if config is provided
+        checkoutOptions?.appAuthentication?.let { appAuth ->
+            val headerValue = "{payload: ${appAuth.token}, version: v2}"
+            headers["Shopify-Checkout-Kit-Consumer"] = headerValue
+            log.d(LOG_TAG, "Added app authentication header for fallback checkout")
+        }
+
+        loadUrl(url, headers)
     }
 
     inner class FallbackWebViewClient : BaseWebView.BaseWebViewClient() {

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/ShopifyCheckoutSheetKit.kt
@@ -89,9 +89,11 @@ public object ShopifyCheckoutSheetKit {
      *
      * @param checkoutUrl The URL of the checkout to be loaded, this can be obtained via the Storefront API
      * @param context The context the checkout is being presented from
+     * @param checkoutOptions Optional configuration options for the checkout
      */
     @JvmStatic
-    public fun preload(checkoutUrl: String, context: ComponentActivity) {
+    @JvmOverloads
+    public fun preload(checkoutUrl: String, context: ComponentActivity, checkoutOptions: CheckoutOptions? = null) {
         log.d("ShopifyCheckoutSheetKit", "Preload called. Preloading enabled ${configuration.preloading.enabled}.")
         if (!configuration.preloading.enabled) return
 
@@ -103,6 +105,7 @@ public object ShopifyCheckoutSheetKit {
             }
 
             log.d("ShopifyCheckoutSheetKit", "Calling loadCheckout on existing view with url $checkoutUrl.")
+            cacheEntry.view.checkoutOptions = checkoutOptions
             cacheEntry.view.loadCheckout(checkoutUrl, false)
         } else {
             log.d("ShopifyCheckoutSheetKit", "Fetching cacheable WebView.")
@@ -111,6 +114,7 @@ public object ShopifyCheckoutSheetKit {
                 url = checkoutUrl,
                 activity = context,
                 isPreload = true,
+                checkoutOptions = checkoutOptions
             )
         }
     }
@@ -122,13 +126,16 @@ public object ShopifyCheckoutSheetKit {
      * @param context The context the checkout is being presented from
      * @param checkoutEventProcessor provides callbacks to allow clients to listen for and respond to checkout lifecycle events such as
      * (failure, completion, cancellation, external link clicks).
+     * @param checkoutOptions Optional configuration options for the checkout
      * @return An instance of [CheckoutSheetKitDialog] if the dialog was successfully created and displayed.
      */
     @JvmStatic
+    @JvmOverloads
     public fun <T : DefaultCheckoutEventProcessor> present(
         checkoutUrl: String,
         context: ComponentActivity,
-        checkoutEventProcessor: T
+        checkoutEventProcessor: T,
+        checkoutOptions: CheckoutOptions? = null
     ): CheckoutSheetKitDialog? {
         log.d("ShopifyCheckoutSheetKit", "Present called with checkoutUrl $checkoutUrl.")
         if (context.isDestroyed || context.isFinishing) {
@@ -136,7 +143,7 @@ public object ShopifyCheckoutSheetKit {
             return null
         }
         log.d("ShopifyCheckoutSheetKit", "Constructing Dialog")
-        val dialog = CheckoutDialog(checkoutUrl, checkoutEventProcessor, context)
+        val dialog = CheckoutDialog(checkoutUrl, checkoutEventProcessor, context, checkoutOptions)
         context.lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onDestroy(owner: LifecycleOwner) {
                 log.d("ShopifyCheckoutSheetKit", "Context is being destroyed, dismissing dialog.")

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/FallbackWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/FallbackWebViewTest.kt
@@ -140,4 +140,53 @@ class FallbackWebViewTest {
             assertThat(view.recoverErrors).isFalse()
         }
     }
+
+    @Test
+    fun `sends authentication header when checkoutOptions appAuthentication is provided`() {
+        Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+            val view = FallbackWebView(activityController.get())
+            val appAuth = CheckoutOptions.AppAuthentication(token = "fallback-jwt-token")
+            val checkoutOptions = CheckoutOptions(appAuthentication = appAuth)
+
+            view.checkoutOptions = checkoutOptions
+            view.loadCheckoutWithHeader("https://test.myshopify.com/checkout")
+
+            val shadow = shadowOf(view)
+
+            val expectedAuthHeaderValue = "{payload: fallback-jwt-token, version: v2}"
+            assertThat(shadow.lastAdditionalHttpHeaders.getOrDefault("Shopify-Checkout-Kit-Consumer", ""))
+                .isEqualTo(expectedAuthHeaderValue)
+        }
+    }
+
+    @Test
+    fun `does not send authentication header when checkoutOptions appAuthentication is null`() {
+        Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+            val view = FallbackWebView(activityController.get())
+            val checkoutOptions = CheckoutOptions(appAuthentication = null)
+
+            view.checkoutOptions = checkoutOptions
+            view.loadCheckoutWithHeader("https://test.myshopify.com/checkout")
+
+            val shadow = shadowOf(view)
+
+            assertThat(shadow.lastAdditionalHttpHeaders.containsKey("Shopify-Checkout-Kit-Consumer"))
+                .isFalse()
+        }
+    }
+
+    @Test
+    fun `does not send authentication header when checkoutOptions is null`() {
+        Robolectric.buildActivity(ComponentActivity::class.java).use { activityController ->
+            val view = FallbackWebView(activityController.get())
+
+            view.checkoutOptions = null
+            view.loadCheckoutWithHeader("https://test.myshopify.com/checkout")
+
+            val shadow = shadowOf(view)
+
+            assertThat(shadow.lastAdditionalHttpHeaders.containsKey("Shopify-Checkout-Kit-Consumer"))
+                .isFalse()
+        }
+    }
 }


### PR DESCRIPTION
### What changes are you making?

- Added support for Partner App Authentication (App Authentication) in Android Checkout Sheet Kit to match the iOS implementation.
- Introduced a new `CheckoutOptions` data class with a nested `AppAuthentication` data class for passing JWT authentication tokens.
- Updated the SDK's public API to accept optional `CheckoutOptions` in the `present` and `preload` methods, maintaining backward compatibility.
- Added logic to set the `Shopify-Checkout-Kit-Consumer` header with the JWT token and hardcoded version (`v2`) when app authentication is provided.
- Updated both `CheckoutWebView` and `FallbackWebView` to support authentication headers for normal and error recovery scenarios.
- Updated the README with a new "App Authentication" section, including detailed, step-by-step instructions and code examples for generating the JWT, encrypting the access token, and integrating with the Android SDK.
- Added tests to verify that the authentication header is correctly set or omitted based on the presence of app authentication.

### How to test

1. **Review the new "App Authentication" section** in the README and follow the steps to generate a JWT.
2. **Integrate the SDK using the new `CheckoutOptions.AppAuthentication(token: ...)` interface:**
   ```kotlin
   val appAuth = CheckoutOptions.AppAuthentication(token = "<JWT_TOKEN>")
   val checkoutOptions = CheckoutOptions(appAuthentication = appAuth)
   ShopifyCheckoutSheetKit.present(checkoutUrl, context, checkoutEventProcessor, checkoutOptions)
   ```
3. **Use the `present` or `preload` methods** with `CheckoutOptions` and verify that the authentication header is set as expected using network inspection tools.
4. **Run the updated and new tests** in `CheckoutWebViewTest.kt` and `FallbackWebViewTest.kt` to ensure the header logic works as intended:
   - Tests for authentication header presence/absence
   - Tests for combination of prefetch + authentication headers
   - Tests for FallbackWebView authentication in error recovery scenarios
5. **Confirm backward compatibility** by testing that all existing API calls continue to work without `CheckoutOptions`.
6. **Test Java interoperability** by verifying that Java code can call the new methods without specifying the optional `CheckoutOptions` parameter.
7. **Verify error recovery** by triggering checkout errors and confirming that FallbackWebView also includes authentication headers when provided.

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
