### PR TITLE
Allow customizing the dialog close icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.4.1 Jun 26, 2025
+
+- Allow configuring a custom close icon, or setting close icon tint
+- Added helpers for customizing color schemes
+
 ## 3.4.0 Jun 11, 2025
 
 - Enable Google Pay payment support.  

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ your project:
 ### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.4.0"
+implementation "com.shopify:checkout-sheet-kit:3.4.1"
 ```
 
 ### Maven
@@ -62,7 +62,7 @@ implementation "com.shopify:checkout-sheet-kit:3.4.0"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.4.0</version>
+   <version>3.4.1</version>
 </dependency>
 ```
 
@@ -175,12 +175,48 @@ val automatic = ColorScheme.Automatic(
 )
 ```
 
+**Close Icon Customization**
+
+The close icon in the checkout dialog header can be customized using the `customize` method for an ergonomic API:
+
+```kotlin
+ShopifyCheckoutSheetKit.configure {
+    it.colorScheme = ColorScheme.Light().customize {
+        // Option 1: Just tint the default close icon
+        closeIconTint = Color.ResourceId(R.color.my_custom_tint_color)
+        
+        // Option 2: Use a completely custom drawable
+        closeIcon = DrawableResource(R.drawable.my_custom_close_icon)
+    }
+}
+```
+
+For automatic theme switching, you can provide different customizations for light and dark modes:
+
+```kotlin
+ShopifyCheckoutSheetKit.configure {
+    it.colorScheme = ColorScheme.Automatic().customize(
+        light = {
+            closeIconTint = Color.ResourceId(R.color.light_tint)
+        },
+        dark = {
+            closeIconTint = Color.ResourceId(R.color.dark_tint)
+        }
+    )
+}
+```
+
+> [!Note]
+> If both `closeIcon` and `closeIconTint` are provided, the custom drawable (`closeIcon`) takes precedence and the tint is ignored.
+
 The colors that can be modified are:
 
 - headerBackground - Used to customize the background of the app bar on the dialog,
 - headerFont - Used to customize the font color of the header text within in the app bar,
 - webViewBackground - Used to customize the background color of the WebView,
 - progressIndicator - Used to customize the color of the progress indicator shown when checkout is loading.
+- closeIcon - Used to provide a completely custom close icon drawable
+- closeIconTint - Used to tint the default close icon with a custom color
 
 The current configuration can be obtained by calling `ShopifyCheckoutSheetKit.getConfiguration()`.
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,7 +14,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.4.0")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.4.1")
 
 ext {
     app_compat_version = '1.6.1'

--- a/lib/detekt.config.yml
+++ b/lib/detekt.config.yml
@@ -1,11 +1,11 @@
 naming:
   EnumNaming:
     active: true
-    excludes: ['**/WebMessage.kt']
+    excludes: [ '**/WebMessage.kt' ]
 style:
   FunctionOnlyReturningConstant:
     active: true
-    excludes: ['**/WebViewController.kt']
+    excludes: [ '**/WebViewController.kt' ]
   MaxLineLength:
     active: true
     maxLineLength: 140
@@ -18,4 +18,4 @@ exceptions:
     active: false
 complexity:
   TooManyFunctions:
-    thresholdInClasses: 15
+    thresholdInClasses: 16

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -32,6 +32,7 @@ import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.view.MenuItem
 import android.view.View.GONE
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
@@ -43,7 +44,9 @@ import android.widget.ProgressBar
 import android.widget.RelativeLayout
 import androidx.activity.ComponentActivity
 import androidx.annotation.ColorInt
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar
+import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.children
 import com.shopify.checkoutsheetkit.ShopifyCheckoutSheetKit.log
 
@@ -77,13 +80,12 @@ internal class CheckoutDialog(
 
         val colorScheme = ShopifyCheckoutSheetKit.configuration.colorScheme
         log.d(LOG_TAG, "Configured colorScheme $colorScheme")
-        val header = findViewById<Toolbar>(R.id.checkoutSdkHeader)
-
-        header.apply {
+        findViewById<Toolbar>(R.id.checkoutSdkHeader).apply {
             log.d(LOG_TAG, "Applying configured header colors and inflating menu.")
             setBackgroundColor(colorScheme.headerBackgroundColor())
             setTitleTextColor(colorScheme.headerFontColor())
             inflateMenu(R.menu.checkout_menu)
+            menu.findItem(R.id.checkoutSdkCloseBtn).apply { setupCloseButton(colorScheme) }
         }
 
         findViewById<ProgressBar>(R.id.progressBar).apply {
@@ -107,12 +109,6 @@ internal class CheckoutDialog(
             removeWebViewFromContainer()
         }
 
-        header.setOnMenuItemClickListener {
-            log.d(LOG_TAG, "Menu click cancel invoked.")
-            cancel()
-            true
-        }
-
         setOnShowListener {
             log.d(LOG_TAG, "On show listener invoked, calling WebView notifyPresented.")
             checkoutWebView.notifyPresented()
@@ -120,6 +116,28 @@ internal class CheckoutDialog(
 
         log.d(LOG_TAG, "Showing dialog.")
         show()
+    }
+
+    private fun MenuItem.setupCloseButton(colorScheme: ColorScheme) {
+        val customCloseIcon = colorScheme.closeIcon(context.isDarkTheme())
+        if (customCloseIcon != null) {
+            log.d(LOG_TAG, "Setting custom menu item drawable.")
+            this.icon = AppCompatResources.getDrawable(context, customCloseIcon.id)
+        } else {
+            val customTint = colorScheme.closeIconTint(context.isDarkTheme())
+            val icon = this.icon
+            if (customTint != null && icon != null) {
+                log.d(LOG_TAG, "Setting menu item tint.")
+                val wrappedDrawable = DrawableCompat.wrap(icon)
+                DrawableCompat.setTint(wrappedDrawable.mutate(), customTint.getValue(context))
+            }
+        }
+
+        setOnMenuItemClickListener {
+            log.d(LOG_TAG, "Menu click cancel invoked.")
+            cancel()
+            true
+        }
     }
 
     private fun removeWebViewFromContainer() {

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/ColorSchemeTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/ColorSchemeTest.kt
@@ -36,6 +36,8 @@ class ColorSchemeTest {
         assertThat(dark.colors.headerFont).isEqualTo(Color.ResourceId(R.color.checkoutDarkFont))
         assertThat(dark.colors.webViewBackground).isEqualTo(Color.ResourceId(R.color.checkoutDarkBg))
         assertThat(dark.colors.progressIndicator).isEqualTo(Color.ResourceId(R.color.checkoutDarkProgressIndicator))
+        assertThat(dark.colors.closeIcon).isNull()
+        assertThat(dark.colors.closeIconTint).isNull()
     }
 
     @Test
@@ -46,6 +48,8 @@ class ColorSchemeTest {
         assertThat(light.colors.headerFont).isEqualTo(Color.ResourceId(R.color.checkoutLightFont))
         assertThat(light.colors.webViewBackground).isEqualTo(Color.ResourceId(R.color.checkoutLightBg))
         assertThat(light.colors.progressIndicator).isEqualTo(Color.ResourceId(R.color.checkoutLightProgressIndicator))
+        assertThat(light.colors.closeIcon).isNull()
+        assertThat(light.colors.closeIconTint).isNull()
     }
 
     @Test
@@ -56,11 +60,15 @@ class ColorSchemeTest {
         assertThat(automatic.darkColors.headerFont).isEqualTo(Color.ResourceId(R.color.checkoutDarkFont))
         assertThat(automatic.darkColors.webViewBackground).isEqualTo(Color.ResourceId(R.color.checkoutDarkBg))
         assertThat(automatic.darkColors.progressIndicator).isEqualTo(Color.ResourceId(R.color.checkoutDarkProgressIndicator))
+        assertThat(automatic.darkColors.closeIcon).isNull()
+        assertThat(automatic.darkColors.closeIconTint).isNull()
 
         assertThat(automatic.lightColors.headerBackground).isEqualTo(Color.ResourceId(R.color.checkoutLightBg))
         assertThat(automatic.lightColors.headerFont).isEqualTo(Color.ResourceId(R.color.checkoutLightFont))
         assertThat(automatic.lightColors.webViewBackground).isEqualTo(Color.ResourceId(R.color.checkoutLightBg))
         assertThat(automatic.lightColors.progressIndicator).isEqualTo(Color.ResourceId(R.color.checkoutLightProgressIndicator))
+        assertThat(automatic.lightColors.closeIcon).isNull()
+        assertThat(automatic.lightColors.closeIconTint).isNull()
     }
 
     @Test
@@ -71,6 +79,8 @@ class ColorSchemeTest {
         assertThat(web.colors.headerFont).isEqualTo(Color.ResourceId(R.color.checkoutLightFont))
         assertThat(web.colors.webViewBackground).isEqualTo(Color.ResourceId(R.color.checkoutLightBg))
         assertThat(web.colors.progressIndicator).isEqualTo(Color.ResourceId(R.color.checkoutLightProgressIndicator))
+        assertThat(web.colors.closeIcon).isNull()
+        assertThat(web.colors.closeIconTint).isNull()
     }
 
     @Test
@@ -192,5 +202,184 @@ class ColorSchemeTest {
         )
             .usingRecursiveComparison()
             .isEqualTo(automatic)
+    }
+
+    @Test
+    fun `closeIcon can be overridden with custom drawable`() {
+        val customIcon = DrawableResource(123)
+        val light = ColorScheme.Light(
+            colors = Colors(
+                headerBackground = Color.ResourceId(R.color.checkoutLightBg),
+                headerFont = Color.ResourceId(R.color.checkoutLightFont),
+                webViewBackground = Color.ResourceId(R.color.checkoutLightBg),
+                progressIndicator = Color.ResourceId(R.color.checkoutLightProgressIndicator),
+                closeIcon = customIcon
+            )
+        )
+
+        assertThat(light.colors.closeIcon).isEqualTo(customIcon)
+    }
+
+    @Test
+    fun `closeIconTint can be overridden with custom color`() {
+        val customTint = Color.ResourceId(456)
+        val dark = ColorScheme.Dark(
+            colors = Colors(
+                headerBackground = Color.ResourceId(R.color.checkoutDarkBg),
+                headerFont = Color.ResourceId(R.color.checkoutDarkFont),
+                webViewBackground = Color.ResourceId(R.color.checkoutDarkBg),
+                progressIndicator = Color.ResourceId(R.color.checkoutDarkProgressIndicator),
+                closeIconTint = customTint
+            )
+        )
+
+        assertThat(dark.colors.closeIconTint).isEqualTo(customTint)
+    }
+
+    @Test
+    fun `closeIcon helper function returns correct icon for light mode`() {
+        val lightIcon = DrawableResource(123)
+        val darkIcon = DrawableResource(456)
+
+        val automatic = ColorScheme.Automatic(
+            lightColors = Colors(
+                headerBackground = Color.ResourceId(1),
+                headerFont = Color.ResourceId(2),
+                webViewBackground = Color.ResourceId(3),
+                progressIndicator = Color.ResourceId(4),
+                closeIcon = lightIcon
+            ),
+            darkColors = Colors(
+                headerBackground = Color.ResourceId(5),
+                headerFont = Color.ResourceId(6),
+                webViewBackground = Color.ResourceId(7),
+                progressIndicator = Color.ResourceId(8),
+                closeIcon = darkIcon
+            )
+        )
+
+        assertThat(automatic.closeIcon(isDark = false)).isEqualTo(lightIcon)
+        assertThat(automatic.closeIcon(isDark = true)).isEqualTo(darkIcon)
+    }
+
+    @Test
+    fun `closeIconTint helper function returns correct tint for dark mode`() {
+        val lightTint = Color.ResourceId(123)
+        val darkTint = Color.ResourceId(456)
+
+        val automatic = ColorScheme.Automatic(
+            lightColors = Colors(
+                headerBackground = Color.ResourceId(1),
+                headerFont = Color.ResourceId(2),
+                webViewBackground = Color.ResourceId(3),
+                progressIndicator = Color.ResourceId(4),
+                closeIconTint = lightTint
+            ),
+            darkColors = Colors(
+                headerBackground = Color.ResourceId(5),
+                headerFont = Color.ResourceId(6),
+                webViewBackground = Color.ResourceId(7),
+                progressIndicator = Color.ResourceId(8),
+                closeIconTint = darkTint
+            )
+        )
+
+        assertThat(automatic.closeIconTint(isDark = false)).isEqualTo(lightTint)
+        assertThat(automatic.closeIconTint(isDark = true)).isEqualTo(darkTint)
+    }
+
+    @Test
+    fun `closeIcon helper function returns null when no custom icon is set`() {
+        val light = ColorScheme.Light()
+        val dark = ColorScheme.Dark()
+        val web = ColorScheme.Web()
+        val automatic = ColorScheme.Automatic()
+
+        assertThat(light.closeIcon(isDark = false)).isNull()
+        assertThat(dark.closeIcon(isDark = true)).isNull()
+        assertThat(web.closeIcon(isDark = false)).isNull()
+        assertThat(automatic.closeIcon(isDark = false)).isNull()
+        assertThat(automatic.closeIcon(isDark = true)).isNull()
+    }
+
+    @Test
+    fun `closeIconTint helper function returns null when no custom tint is set`() {
+        val light = ColorScheme.Light()
+        val dark = ColorScheme.Dark()
+        val web = ColorScheme.Web()
+        val automatic = ColorScheme.Automatic()
+
+        assertThat(light.closeIconTint(isDark = false)).isNull()
+        assertThat(dark.closeIconTint(isDark = true)).isNull()
+        assertThat(web.closeIconTint(isDark = false)).isNull()
+        assertThat(automatic.closeIconTint(isDark = false)).isNull()
+        assertThat(automatic.closeIconTint(isDark = true)).isNull()
+    }
+
+    @Test
+    fun `customize allows easy modification of single properties`() {
+        val originalScheme = ColorScheme.Light()
+        val customTint = Color.ResourceId(456)
+
+        val customizedScheme = originalScheme.customize {
+            closeIconTint = customTint
+        }
+
+        assertThat(customizedScheme).isInstanceOf(ColorScheme.Light::class.java)
+        val lightScheme = customizedScheme as ColorScheme.Light
+        assertThat(lightScheme.colors.closeIconTint).isEqualTo(customTint)
+
+        // Other properties should remain unchanged
+        assertThat(lightScheme.colors.headerBackground).isEqualTo(originalScheme.colors.headerBackground)
+        assertThat(lightScheme.colors.headerFont).isEqualTo(originalScheme.colors.headerFont)
+    }
+
+    @Test
+    fun `customize with Java-friendly builder methods`() {
+        val originalScheme = ColorScheme.Dark()
+        val customIcon = DrawableResource(123)
+        val customTint = Color.SRGB(0xFF0000)
+
+        val customizedScheme = originalScheme.customize {
+            withCloseIcon(customIcon)
+                .withCloseIconTint(customTint)
+        }
+
+        assertThat(customizedScheme).isInstanceOf(ColorScheme.Dark::class.java)
+        val darkScheme = customizedScheme as ColorScheme.Dark
+        assertThat(darkScheme.colors.closeIcon).isEqualTo(customIcon)
+        assertThat(darkScheme.colors.closeIconTint).isEqualTo(customTint)
+    }
+
+    @Test
+    fun `customize with automatic scheme applies to both light and dark`() {
+        val originalScheme = ColorScheme.Automatic()
+        val customTint = Color.ResourceId(789)
+
+        val customizedScheme = originalScheme.customize {
+            closeIconTint = customTint
+        }
+
+        assertThat(customizedScheme).isInstanceOf(ColorScheme.Automatic::class.java)
+        val autoScheme = customizedScheme as ColorScheme.Automatic
+        assertThat(autoScheme.lightColors.closeIconTint).isEqualTo(customTint)
+        assertThat(autoScheme.darkColors.closeIconTint).isEqualTo(customTint)
+    }
+
+    @Test
+    fun `customize with separate light and dark blocks for automatic scheme`() {
+        val originalScheme = ColorScheme.Automatic()
+        val lightTint = Color.ResourceId(111)
+        val darkTint = Color.ResourceId(222)
+
+        val customizedScheme = originalScheme.customize(
+            light = { closeIconTint = lightTint },
+            dark = { closeIconTint = darkTint }
+        )
+
+        assertThat(customizedScheme).isInstanceOf(ColorScheme.Automatic::class.java)
+        val autoScheme = customizedScheme as ColorScheme.Automatic
+        assertThat(autoScheme.lightColors.closeIconTint).isEqualTo(lightTint)
+        assertThat(autoScheme.darkColors.closeIconTint).isEqualTo(darkTint)
     }
 }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/InteropTest.java
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/InteropTest.java
@@ -30,6 +30,107 @@ import kotlinx.serialization.json.JsonKt;
 
 @RunWith(RobolectricTestRunner.class)
 public class InteropTest {
+    private final String EXAMPLE_EVENT = "{\n" +
+            "      \"orderDetails\": {\n" +
+            "        \"id\": \"gid://shopify/OrderIdentity/9697125302294\",\n" +
+            "        \"cart\": {\n" +
+            "          \"token\": \"123abc\",\n" +
+            "          \"lines\": [\n" +
+            "            {\n" +
+            "              \"image\": {\n" +
+            "                \"sm\": \"https://cdn.shopify.com/s/files/1/0692/3996/3670/files/41bc5767-d56f-432c-ac5f-6b9eeee3ba0e.truncated...\",\n" +
+            "                \"md\": \"https://cdn.shopify.com/s/files/1/0692/3996/3670/files/41bc5767-d56f-432c-ac5f-6b9eeee3ba0e.truncated...\",\n" +
+            "                \"lg\": \"https://cdn.shopify.com/s/files/1/0692/3996/3670/files/41bc5767-d56f-432c-ac5f-6b9eeee3ba0e.truncated...\"\n" +
+            "              },\n" +
+            "              \"quantity\": 1,\n" +
+            "              \"title\": \"The Box: How the Shipping Container Made the World Smaller and the World Economy Bigger\",\n" +
+            "              \"price\": {\n" +
+            "                \"amount\": 8,\n" +
+            "                \"currencyCode\": \"GBP\"\n" +
+            "              },\n" +
+            "              \"merchandiseId\": \"gid://shopify/ProductVariant/43835075002390\",\n" +
+            "              \"productId\": \"gid://shopify/Product/8013997834262\"\n" +
+            "            }\n" +
+            "          ],\n" +
+            "          \"price\": {\n" +
+            "            \"total\": {\n" +
+            "              \"amount\": 13.99,\n" +
+            "              \"currencyCode\": \"GBP\"\n" +
+            "            },\n" +
+            "            \"subtotal\": {\n" +
+            "              \"amount\": 8,\n" +
+            "              \"currencyCode\": \"GBP\"\n" +
+            "            },\n" +
+            "            \"taxes\": {\n" +
+            "              \"amount\": 0,\n" +
+            "              \"currencyCode\": \"GBP\"\n" +
+            "            },\n" +
+            "            \"shipping\": {\n" +
+            "              \"amount\": 5.99,\n" +
+            "              \"currencyCode\": \"GBP\"\n" +
+            "            }\n" +
+            "          }\n" +
+            "        },\n" +
+            "        \"email\": \"a.user@shopify.com\",\n" +
+            "        \"shippingAddress\": {\n" +
+            "          \"city\": \"Swansea\",\n" +
+            "          \"countryCode\": \"GB\",\n" +
+            "          \"postalCode\": \"SA1 1AB\",\n" +
+            "          \"address1\": \"100 Street Avenue\",\n" +
+            "          \"firstName\": \"Andrew\",\n" +
+            "          \"lastName\": \"Person\",\n" +
+            "          \"name\": \"Andrew\",\n" +
+            "          \"zoneCode\": \"WLS\",\n" +
+            "          \"phone\": \"+447915123456\",\n" +
+            "          \"coordinates\": {\n" +
+            "            \"latitude\": 54.5936785,\n" +
+            "            \"longitude\": -3.013167399999999\n" +
+            "          }\n" +
+            "        },\n" +
+            "        \"billingAddress\": {\n" +
+            "          \"city\": \"Swansea\",\n" +
+            "          \"countryCode\": \"GB\",\n" +
+            "          \"postalCode\": \"SA1 1AB\",\n" +
+            "          \"address1\": \"100 Street Avenue\",\n" +
+            "          \"firstName\": \"Andrew\",\n" +
+            "          \"lastName\": \"Person\",\n" +
+            "          \"zoneCode\": \"WLS\",\n" +
+            "          \"phone\": \"+447915123456\"\n" +
+            "        },\n" +
+            "        \"paymentMethods\": [\n" +
+            "          {\n" +
+            "            \"type\": \"wallet\",\n" +
+            "            \"details\": {\n" +
+            "              \"amount\": \"13.99\",\n" +
+            "              \"currency\": \"GBP\",\n" +
+            "              \"name\": \"SHOP_PAY\"\n" +
+            "            }\n" +
+            "          }\n" +
+            "        ],\n" +
+            "        \"deliveries\": [\n" +
+            "          {\n" +
+            "            \"method\": \"SHIPPING\",\n" +
+            "            \"details\": {\n" +
+            "              \"location\": {\n" +
+            "                \"city\": \"Swansea\",\n" +
+            "                \"countryCode\": \"GB\",\n" +
+            "                \"postalCode\": \"SA1 1AB\",\n" +
+            "                \"address1\": \"100 Street Avenue\",\n" +
+            "                \"firstName\": \"Andrew\",\n" +
+            "                \"lastName\": \"Person\",\n" +
+            "                \"name\": \"Andrew\",\n" +
+            "                \"zoneCode\": \"WLS\",\n" +
+            "                \"phone\": \"+447915123456\",\n" +
+            "                \"coordinates\": {\n" +
+            "                  \"latitude\": 54.5936785,\n" +
+            "                  \"longitude\": -3.013167399999999\n" +
+            "                }\n" +
+            "              }\n" +
+            "            }\n" +
+            "          }\n" +
+            "        ]\n" +
+            "      }\n" +
+            "    }";
     private Configuration initialConfiguration = null;
 
     @Before
@@ -81,21 +182,21 @@ public class InteropTest {
     public void canAccessFieldsOnPixelEvents() {
         String orderId = "123";
         String eventString = "{" +
-            "\"name\": \"checkout_started\"," +
-            "\"event\": {" +
+                "\"name\": \"checkout_started\"," +
+                "\"event\": {" +
                 "\"type\": \"standard\"," +
                 "\"id\": \"sh-88153c5a-8F2D-4CCA-3231-EF5C032A4C3B\"," +
                 "\"name\": \"checkout_started\"," +
                 "\"timestamp\": \"2023-12-20T16:39:23+0000\"," +
                 "\"data\": {" +
-                    "\"checkout\": {" +
-                        "\"order\": {" +
-                        "\"id\": \"" + orderId + "\"" +
-                        "}" +
-                    "}" +
+                "\"checkout\": {" +
+                "\"order\": {" +
+                "\"id\": \"" + orderId + "\"" +
                 "}" +
-            "}" +
-        "}";
+                "}" +
+                "}" +
+                "}" +
+                "}";
 
         WebToSdkEvent webEvent = new WebToSdkEvent("webPixels", eventString);
         Json json = Json.Default;
@@ -110,16 +211,16 @@ public class InteropTest {
         String checkoutStartedOrderId = checkoutStartedData.getCheckout().getOrder().getId();
 
         assertThat(checkoutStartedOrderId).isEqualTo(orderId);
-     }
+    }
 
     @SuppressWarnings("all")
     @Test
     public void canAccessFieldsOnExceptions() {
         String eventString = "[{" +
-            "\"group\": \"expired\"," +
-            "\"reason\": \"Checkout has expired\"," +
-            "\"code\": \"cart_completed\"" +
-        "}]";
+                "\"group\": \"expired\"," +
+                "\"reason\": \"Checkout has expired\"," +
+                "\"code\": \"cart_completed\"" +
+                "}]";
 
         WebToSdkEvent webEvent = new WebToSdkEvent("error", eventString);
         Json json = JsonKt.Json(Json.Default, b -> {
@@ -191,24 +292,24 @@ public class InteropTest {
         try (ActivityController<ComponentActivity> controller = Robolectric.buildActivity(ComponentActivity.class)) {
             ComponentActivity activity = controller.get();
             CheckoutSheetKitDialog dialog = ShopifyCheckoutSheetKit.present(
-                "https://shopify.dev",
-                activity,
-                new DefaultCheckoutEventProcessor(activity) {
-                    @Override
-                    public void onCheckoutCompleted(@NonNull CheckoutCompletedEvent checkoutCompletedEvent) {
-                        // do nothing
-                    }
+                    "https://shopify.dev",
+                    activity,
+                    new DefaultCheckoutEventProcessor(activity) {
+                        @Override
+                        public void onCheckoutCompleted(@NonNull CheckoutCompletedEvent checkoutCompletedEvent) {
+                            // do nothing
+                        }
 
-                    @Override
-                    public void onCheckoutFailed(@NonNull CheckoutException error) {
-                        // do nothing
-                    }
+                        @Override
+                        public void onCheckoutFailed(@NonNull CheckoutException error) {
+                            // do nothing
+                        }
 
-                    @Override
-                    public void onCheckoutCanceled() {
-                        // do nothing
+                        @Override
+                        public void onCheckoutCanceled() {
+                            // do nothing
+                        }
                     }
-                }
             );
 
             assertThat(dialog).isNotNull();
@@ -219,105 +320,90 @@ public class InteropTest {
         }
     }
 
-    private final String EXAMPLE_EVENT = "{\n" +
-     "      \"orderDetails\": {\n" +
-     "        \"id\": \"gid://shopify/OrderIdentity/9697125302294\",\n" +
-     "        \"cart\": {\n" +
-     "          \"token\": \"123abc\",\n" +
-     "          \"lines\": [\n" +
-     "            {\n" +
-     "              \"image\": {\n" +
-     "                \"sm\": \"https://cdn.shopify.com/s/files/1/0692/3996/3670/files/41bc5767-d56f-432c-ac5f-6b9eeee3ba0e.truncated...\",\n" +
-     "                \"md\": \"https://cdn.shopify.com/s/files/1/0692/3996/3670/files/41bc5767-d56f-432c-ac5f-6b9eeee3ba0e.truncated...\",\n" +
-     "                \"lg\": \"https://cdn.shopify.com/s/files/1/0692/3996/3670/files/41bc5767-d56f-432c-ac5f-6b9eeee3ba0e.truncated...\"\n" +
-     "              },\n" +
-     "              \"quantity\": 1,\n" +
-     "              \"title\": \"The Box: How the Shipping Container Made the World Smaller and the World Economy Bigger\",\n" +
-     "              \"price\": {\n" +
-     "                \"amount\": 8,\n" +
-     "                \"currencyCode\": \"GBP\"\n" +
-     "              },\n" +
-     "              \"merchandiseId\": \"gid://shopify/ProductVariant/43835075002390\",\n" +
-     "              \"productId\": \"gid://shopify/Product/8013997834262\"\n" +
-     "            }\n" +
-     "          ],\n" +
-     "          \"price\": {\n" +
-     "            \"total\": {\n" +
-     "              \"amount\": 13.99,\n" +
-     "              \"currencyCode\": \"GBP\"\n" +
-     "            },\n" +
-     "            \"subtotal\": {\n" +
-     "              \"amount\": 8,\n" +
-     "              \"currencyCode\": \"GBP\"\n" +
-     "            },\n" +
-     "            \"taxes\": {\n" +
-     "              \"amount\": 0,\n" +
-     "              \"currencyCode\": \"GBP\"\n" +
-     "            },\n" +
-     "            \"shipping\": {\n" +
-     "              \"amount\": 5.99,\n" +
-     "              \"currencyCode\": \"GBP\"\n" +
-     "            }\n" +
-     "          }\n" +
-     "        },\n" +
-     "        \"email\": \"a.user@shopify.com\",\n" +
-     "        \"shippingAddress\": {\n" +
-     "          \"city\": \"Swansea\",\n" +
-     "          \"countryCode\": \"GB\",\n" +
-     "          \"postalCode\": \"SA1 1AB\",\n" +
-     "          \"address1\": \"100 Street Avenue\",\n" +
-     "          \"firstName\": \"Andrew\",\n" +
-     "          \"lastName\": \"Person\",\n" +
-     "          \"name\": \"Andrew\",\n" +
-     "          \"zoneCode\": \"WLS\",\n" +
-     "          \"phone\": \"+447915123456\",\n" +
-     "          \"coordinates\": {\n" +
-     "            \"latitude\": 54.5936785,\n" +
-     "            \"longitude\": -3.013167399999999\n" +
-     "          }\n" +
-     "        },\n" +
-     "        \"billingAddress\": {\n" +
-     "          \"city\": \"Swansea\",\n" +
-     "          \"countryCode\": \"GB\",\n" +
-     "          \"postalCode\": \"SA1 1AB\",\n" +
-     "          \"address1\": \"100 Street Avenue\",\n" +
-     "          \"firstName\": \"Andrew\",\n" +
-     "          \"lastName\": \"Person\",\n" +
-     "          \"zoneCode\": \"WLS\",\n" +
-     "          \"phone\": \"+447915123456\"\n" +
-     "        },\n" +
-     "        \"paymentMethods\": [\n" +
-     "          {\n" +
-     "            \"type\": \"wallet\",\n" +
-     "            \"details\": {\n" +
-     "              \"amount\": \"13.99\",\n" +
-     "              \"currency\": \"GBP\",\n" +
-     "              \"name\": \"SHOP_PAY\"\n" +
-     "            }\n" +
-     "          }\n" +
-     "        ],\n" +
-     "        \"deliveries\": [\n" +
-     "          {\n" +
-     "            \"method\": \"SHIPPING\",\n" +
-     "            \"details\": {\n" +
-     "              \"location\": {\n" +
-     "                \"city\": \"Swansea\",\n" +
-     "                \"countryCode\": \"GB\",\n" +
-     "                \"postalCode\": \"SA1 1AB\",\n" +
-     "                \"address1\": \"100 Street Avenue\",\n" +
-     "                \"firstName\": \"Andrew\",\n" +
-     "                \"lastName\": \"Person\",\n" +
-     "                \"name\": \"Andrew\",\n" +
-     "                \"zoneCode\": \"WLS\",\n" +
-     "                \"phone\": \"+447915123456\",\n" +
-     "                \"coordinates\": {\n" +
-     "                  \"latitude\": 54.5936785,\n" +
-     "                  \"longitude\": -3.013167399999999\n" +
-     "                }\n" +
-     "              }\n" +
-     "            }\n" +
-     "          }\n" +
-     "        ]\n" +
-     "      }\n" +
-     "    }";
+    @Test
+    public void canCustomizeColorSchemeWithSingleBlock() {
+        ColorScheme.Light lightScheme = new ColorScheme.Light();
+        Color tintColor = new Color.ResourceId(android.R.color.holo_red_dark);
+
+        ColorScheme customized = lightScheme.customize(builder -> {
+            builder.setCloseIconTint(tintColor);
+            return null;
+        });
+
+        assertThat(customized).isInstanceOf(ColorScheme.Light.class);
+        ColorScheme.Light customizedLight = (ColorScheme.Light) customized;
+        assertThat(customizedLight.getColors().getCloseIconTint()).isEqualTo(tintColor);
+    }
+
+    @Test
+    public void canCustomizeColorSchemeWithLightAndDarkBlocks() {
+        ColorScheme.Automatic autoScheme = new ColorScheme.Automatic();
+        Color lightTint = new Color.ResourceId(android.R.color.holo_orange_light);
+        Color darkTint = new Color.ResourceId(android.R.color.holo_blue_dark);
+        DrawableResource customIcon = new DrawableResource(android.R.drawable.ic_menu_close_clear_cancel);
+
+        ColorScheme customized = autoScheme.customize(
+                lightBuilder -> {
+                    lightBuilder.setCloseIconTint(lightTint);
+                    return null;
+                },
+                darkBuilder -> {
+                    darkBuilder.setCloseIcon(customIcon);
+                    darkBuilder.setCloseIconTint(darkTint);
+                    return null;
+                }
+        );
+
+        assertThat(customized).isInstanceOf(ColorScheme.Automatic.class);
+        ColorScheme.Automatic customizedAuto = (ColorScheme.Automatic) customized;
+
+        assertThat(customizedAuto.getLightColors().getCloseIconTint()).isEqualTo(lightTint);
+        assertThat(customizedAuto.getLightColors().getCloseIcon()).isNull();
+
+        assertThat(customizedAuto.getDarkColors().getCloseIconTint()).isEqualTo(darkTint);
+        assertThat(customizedAuto.getDarkColors().getCloseIcon()).isEqualTo(customIcon);
+    }
+
+    @Test
+    public void canUseColorsBuilderDirectPropertyAssignment() {
+        ColorScheme.Dark darkScheme = new ColorScheme.Dark();
+        Color headerColor = new Color.SRGB(0xFF123456);
+        Color tintColor = new Color.SRGB(0xFFABCDEF);
+
+        ColorScheme customized = darkScheme.customize(builder -> {
+            builder.setHeaderBackground(headerColor);
+            builder.setCloseIconTint(tintColor);
+            return null;
+        });
+
+        assertThat(customized).isInstanceOf(ColorScheme.Dark.class);
+        ColorScheme.Dark customizedDark = (ColorScheme.Dark) customized;
+        assertThat(customizedDark.getColors().getHeaderBackground()).isEqualTo(headerColor);
+        assertThat(customizedDark.getColors().getCloseIconTint()).isEqualTo(tintColor);
+    }
+
+    @Test
+    public void canChainColorsBuilderMethods() {
+        ColorScheme.Web webScheme = new ColorScheme.Web();
+        Color webViewBg = new Color.ResourceId(android.R.color.white);
+        Color progressColor = new Color.ResourceId(android.R.color.holo_green_dark);
+        DrawableResource icon = new DrawableResource(android.R.drawable.ic_menu_close_clear_cancel);
+
+        ColorScheme customized = webScheme.customize(builder -> {
+            builder
+                    .withWebViewBackground(webViewBg)
+                    .withProgressIndicator(progressColor)
+                    .withCloseIcon(icon);
+            // return null is slightly awkward, but we're prioritizing the kotlin interface
+            return null;
+        });
+
+        assertThat(customized).isInstanceOf(ColorScheme.Web.class);
+        ColorScheme.Web customizedWeb = (ColorScheme.Web) customized;
+        Colors colors = customizedWeb.getColors();
+
+        assertThat(colors.getWebViewBackground()).isEqualTo(webViewBg);
+        assertThat(colors.getProgressIndicator()).isEqualTo(progressColor);
+        assertThat(colors.getCloseIcon()).isEqualTo(icon);
+    }
 }

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/MobileBuyIntegration.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/MobileBuyIntegration.kt
@@ -26,6 +26,7 @@ import android.app.Application
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.CookiePurger
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.di.setupDI
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.logs.Logger
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.withCustomCloseIcon
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.PreferencesManager
 import com.shopify.checkoutsheetkit.CheckoutException
 import com.shopify.checkoutsheetkit.ErrorRecovery
@@ -58,7 +59,7 @@ class MobileBuyIntegration : Application() {
             val settings = preferencesManager.userPreferencesFlow.first()
             ShopifyCheckoutSheetKit.configure {
                 it.logLevel = LogLevel.DEBUG
-                it.colorScheme = settings.colorScheme
+                it.colorScheme = settings.colorScheme.withCustomCloseIcon()
                 it.preloading = settings.preloading
                 it.errorRecovery = object : ErrorRecovery {
                     val logger: Logger by inject()

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/ColorSchemeExtensions.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/ColorSchemeExtensions.kt
@@ -1,0 +1,44 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkout_sdk_mobile_buy_integration_sample.common
+
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.R
+import com.shopify.checkoutsheetkit.Color
+import com.shopify.checkoutsheetkit.ColorScheme
+
+fun ColorScheme.withCustomCloseIcon(): ColorScheme {
+    return when (this) {
+        is ColorScheme.Automatic -> {
+            this.customize(
+                light = { closeIconTint = Color.ResourceId(R.color.light_theme_close_icon) },
+                dark = { closeIconTint = Color.ResourceId(R.color.dark_theme_close_icon) }
+            )
+        }
+
+        else -> {
+            this.customize {
+                closeIconTint = Color.ResourceId(R.color.light_theme_close_icon)
+            }
+        }
+    }
+}

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/settings/SettingsViewModel.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/settings/SettingsViewModel.kt
@@ -25,6 +25,7 @@ package com.shopify.checkout_sdk_mobile_buy_integration_sample.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.BuildConfig
+import com.shopify.checkout_sdk_mobile_buy_integration_sample.common.withCustomCloseIcon
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.authentication.data.CustomerRepository
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.data.Settings
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.data.SettingsRepository
@@ -59,7 +60,7 @@ class SettingsViewModel(
 
     fun setColorScheme(colorScheme: ColorScheme) = viewModelScope.launch {
         ShopifyCheckoutSheetKit.configure {
-            it.colorScheme = colorScheme
+            it.colorScheme = colorScheme.withCustomCloseIcon()
         }
         settingsRepository.setColorScheme(colorScheme)
     }

--- a/samples/MobileBuyIntegration/app/src/main/res/values/colors.xml
+++ b/samples/MobileBuyIntegration/app/src/main/res/values/colors.xml
@@ -4,4 +4,6 @@
     <color name="header_bg">#f0f0e8</color>
     <color name="header_font">#000</color>
     <color name="bright_progress_indicator">#ffff00</color>
+    <color name="light_theme_close_icon">#0000FF</color>
+    <color name="dark_theme_close_icon">#00CCFF</color>
 </resources>


### PR DESCRIPTION
### What changes are you making?

Allow customizing the dialog close icon.  Either via setting a tint, or replacing the icon completely.  And some helpers for makign customizing individual colors in a colorScheme easier.

Example of using the light color scheme with a custom icon tint:

```kotlin
ShopifyCheckoutSheetKit.configure {
    it.colorScheme = ColorScheme.Light().customize {
        closeIconTint = Color.ResourceId(R.color.light_theme_close_icon) 
    }
}
```

Via RGB rather than drawable resource:
```kotlin
ShopifyCheckoutSheetKit.configure {
    it.colorScheme = ColorScheme.Light().customize {
        closeIconTint = Color.SRGB(android.graphics.Color.rgb(255, 255, 0))
    }
}
```

Or a replacing the icon:

```kotlin
ShopifyCheckoutSheetKit.configure {
    it.colorScheme = ColorScheme.Light().customize {
       closeIcon = DrawableResource(android.R.drawable.ic_menu_close_clear_cancel)
    }
}
```

#### Vids:

#### No customization / default (current)

https://github.com/user-attachments/assets/9308d756-fab0-4a3f-8c50-ace1f340a1ae

#### Customized tint

https://github.com/user-attachments/assets/84cf6355-b283-4c7c-a133-8ec91c437266

#### Customized icon

https://github.com/user-attachments/assets/d043ffce-4459-42de-a745-5b1ad55cb200

### How to test

I added some customization in the MobileBuySample to test it out. Modify ColorSchemeExtensions to try out the variations

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [x] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [x] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
