### PR TITLE
Sample app dependency bump

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/Configuration.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/Configuration.kt
@@ -29,7 +29,6 @@ package com.shopify.checkoutsheetkit
  * - Enabling/disabling preloading,
  * - Specifying the colorScheme that should be used for checkout.
  */
-@ConsistentCopyVisibility
 public data class Configuration internal constructor(
     var colorScheme: ColorScheme = ColorScheme.Automatic(),
     var preloading: Preloading = Preloading(),

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/Configuration.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/Configuration.kt
@@ -29,6 +29,7 @@ package com.shopify.checkoutsheetkit
  * - Enabling/disabling preloading,
  * - Specifying the colorScheme that should be used for checkout.
  */
+@ConsistentCopyVisibility
 public data class Configuration internal constructor(
     var colorScheme: ColorScheme = ColorScheme.Automatic(),
     var preloading: Preloading = Preloading(),

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/Helpers.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/Helpers.kt
@@ -99,14 +99,16 @@ class CheckoutExceptionAssert(actual: CheckoutException) :
     }
 }
 
-fun noopDefaultCheckoutEventProcessor(activity: Activity): DefaultCheckoutEventProcessor {
-    return object : DefaultCheckoutEventProcessor(activity) {
+fun noopDefaultCheckoutEventProcessor(activity: Activity, log: LogWrapper = LogWrapper()): DefaultCheckoutEventProcessor {
+    return object : DefaultCheckoutEventProcessor(activity, log) {
         override fun onCheckoutCompleted(checkoutCompletedEvent: CheckoutCompletedEvent) {
             // no-op
         }
+
         override fun onCheckoutFailed(error: CheckoutException) {
             // no-op
         }
+
         override fun onCheckoutCanceled() {
             // no-op
         }

--- a/samples/MobileBuyIntegration/app/build.gradle
+++ b/samples/MobileBuyIntegration/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.kotlin.plugin.serialization'
     id 'com.google.devtools.ksp'
+    id 'org.jetbrains.kotlin.plugin.compose'
 }
 
 def loadProperties() {
@@ -103,22 +104,22 @@ dependencies {
     implementation "androidx.datastore:datastore-preferences:$datastore_version"
     implementation "io.insert-koin:koin-androidx-compose:$koin_android_compose_version"
     implementation "androidx.room:room-runtime:$room_version"
-    implementation 'androidx.compose.material3:material3-android:1.3.1'
-    implementation 'androidx.paging:paging-compose-android:3.3.4'
+    implementation "androidx.compose.material3:material3-android:$material3_version"
+    implementation "androidx.paging:paging-compose-android:$paging_version"
 
-    // Encrypted shared preferences
-    implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha06'
+    implementation "androidx.annotation:annotation:${annotation_version}"
 
     annotationProcessor "androidx.room:room-compiler:$room_version"
     ksp "androidx.room:room-compiler:$room_version"
 
     // SDK facilitating calling the Shopify Storefront API
-    implementation("com.shopify.mobilebuysdk:buy3:$mobile_buy_version") {
-        exclude group: 'com.shopify.graphql.support', module: 'support'
-    }
+    implementation("com.shopify.mobilebuysdk:buy3:$mobile_buy_version")
 
     // Image loading library
     implementation "io.coil-kt:coil-compose:$coil_version"
+
+    // Logging
+    implementation "com.jakewharton.timber:timber:$timber_version"
 
     // Serialization
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlin_serialization_version"

--- a/samples/MobileBuyIntegration/app/build.gradle
+++ b/samples/MobileBuyIntegration/app/build.gradle
@@ -38,7 +38,7 @@ android {
     defaultConfig {
         applicationId "com.shopify.checkout_sdk_mobile_buy_integration_sample"
         minSdk 28
-        targetSdk 34
+        targetSdk 36
         versionCode 34
         versionName "0.0.${versionCode}"
 
@@ -107,13 +107,11 @@ dependencies {
     implementation "androidx.compose.material3:material3-android:$material3_version"
     implementation "androidx.paging:paging-compose-android:$paging_version"
 
-    implementation "androidx.annotation:annotation:${annotation_version}"
-
     annotationProcessor "androidx.room:room-compiler:$room_version"
     ksp "androidx.room:room-compiler:$room_version"
 
     // SDK facilitating calling the Shopify Storefront API
-    implementation("com.shopify.mobilebuysdk:buy3:$mobile_buy_version")
+    implementation "com.shopify.mobilebuysdk:buy3:$mobile_buy_version"
 
     // Image loading library
     implementation "io.coil-kt:coil-compose:$coil_version"

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/CheckoutSdkApp.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/CheckoutSdkApp.kt
@@ -71,20 +71,15 @@ import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.SettingsU
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.settings.SettingsViewModel
 import com.shopify.checkoutsheetkit.ColorScheme
 import kotlinx.coroutines.launch
-import org.koin.androidx.compose.KoinAndroidContext
 import org.koin.androidx.compose.koinViewModel
-import org.koin.core.annotation.KoinExperimentalAPI
 
-@OptIn(KoinExperimentalAPI::class)
 @Composable
 fun CheckoutSdkApp() {
-    KoinAndroidContext {
-        val settingsViewModel = koinViewModel<SettingsViewModel>()
-        val cartViewModel = koinViewModel<CartViewModel>()
-        val logsViewModel = koinViewModel<LogsViewModel>()
+    val settingsViewModel = koinViewModel<SettingsViewModel>()
+    val cartViewModel = koinViewModel<CartViewModel>()
+    val logsViewModel = koinViewModel<LogsViewModel>()
 
-        CheckoutSdkAppRoot(settingsViewModel, cartViewModel, logsViewModel)
-    }
+    CheckoutSdkAppRoot(settingsViewModel, cartViewModel, logsViewModel)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/CartView.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/CartView.kt
@@ -23,6 +23,7 @@
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.cart
 
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -52,7 +53,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -83,7 +83,7 @@ fun <T : DefaultCheckoutEventProcessor> CartView(
     val state = cartViewModel.cartState.collectAsState().value
     val loading = cartViewModel.loadingState.collectAsState().value
 
-    val activity = LocalContext.current as ComponentActivity
+    val activity = LocalActivity.current as ComponentActivity
     var mutableQuantity by remember { mutableStateOf<Map<String, Int>>(mutableMapOf()) }
 
     LaunchedEffect(key1 = true) {

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/data/source/network/CartStorefrontApiClient.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/cart/data/source/network/CartStorefrontApiClient.kt
@@ -109,7 +109,7 @@ class CartStorefrontApiClient(
         failureCallback: ((GraphError) -> Unit)? = {},
     ) {
         val mutation = Storefront.mutation { mutation ->
-            mutation.cartLinesAdd(lines, cartId) { cartLinesAddPayload ->
+            mutation.cartLinesAdd(cartId, lines) { cartLinesAddPayload ->
                 cartLinesAddPayload.cart { cartQuery ->
                     cartQueryFragment(cartQuery)
                 }.userErrors { errors ->

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/components/MoneyText.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/components/MoneyText.kt
@@ -23,7 +23,6 @@
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.common.components
 
 import android.content.Context
-import android.os.Build
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -46,11 +45,7 @@ fun MoneyText(
     textAlign: TextAlign = TextAlign.Start,
     includeSuffix: Boolean = true,
 ) {
-    val locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        LocalConfiguration.current.locales.get(0)
-    } else {
-        LocalConfiguration.current.locale
-    }
+    val locale = LocalConfiguration.current.locales.get(0)
 
     Text(
         modifier = modifier,
@@ -79,11 +74,7 @@ fun MoneyRangeText(
     textAlign: TextAlign = TextAlign.Start,
     includeSuffix: Boolean = true,
 ) {
-    val locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        LocalConfiguration.current.locales.get(0)
-    } else {
-        LocalConfiguration.current.locale
-    }
+    val locale = LocalConfiguration.current.locales.get(0)
 
     Text(
         modifier = modifier,

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/di/AppModule.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/common/di/AppModule.kt
@@ -62,9 +62,9 @@ import okhttp3.OkHttpClient
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
-import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.context.startKoin
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
 fun setupDI(application: Application) {
@@ -86,7 +86,6 @@ val appModules = module {
     single {
         CustomerAccessTokenStore(
             appContext = androidApplication().applicationContext,
-            scope = CoroutineScope(Dispatchers.Default),
         )
     }
 

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/settings/ColorSchemeSection.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/settings/ColorSchemeSection.kt
@@ -22,7 +22,7 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.settings
 
-import android.support.annotation.StringRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/settings/ColorSchemeSection.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/settings/ColorSchemeSection.kt
@@ -22,7 +22,6 @@
  */
 package com.shopify.checkout_sdk_mobile_buy_integration_sample.settings
 
-import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -151,7 +150,7 @@ fun ColorSchemeOption(
 }
 
 private val ColorScheme.name: Int
-    @StringRes get() = when (this) {
+    get() = when (this) {
         is ColorScheme.Light -> R.string.color_scheme_light
         is ColorScheme.Dark -> R.string.color_scheme_dark
         is ColorScheme.Web -> R.string.color_scheme_web

--- a/samples/MobileBuyIntegration/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/samples/MobileBuyIntegration/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@mipmap/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
-</adaptive-icon>

--- a/samples/MobileBuyIntegration/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/samples/MobileBuyIntegration/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@mipmap/ic_launcher_background"/>
-    <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
-</adaptive-icon>

--- a/samples/MobileBuyIntegration/build.gradle
+++ b/samples/MobileBuyIntegration/build.gradle
@@ -1,21 +1,20 @@
 buildscript {
     ext {
-        app_compat_version = '1.7.1'
-        core_version = '1.16.0'
         activity_version = '1.10.1'
-        annotation_version = '1.9.1'
-        lifecycle_version = '2.7.0'
-        datastore_version = '1.1.1'
-        nav_version = '2.9.0'
+        app_compat_version = '1.7.1'
         compose_ui_version = '1.8.3'
-        mobile_buy_version = '2025.4.1'
         coil_version = '2.7.0'
-        timber_version = '5.0.1'
-        kotlin_serialization_version = '1.8.1'
+        core_version = '1.16.0'
+        datastore_version = '1.1.1'
         koin_android_compose_version = '4.1.0'
-        room_version = '2.6.1'
-        paging_version = '3.3.6'
+        kotlin_serialization_version = '1.8.1'
+        lifecycle_version = '2.7.0'
         material3_version = '1.3.2'
+        mobile_buy_version = '2025.4.1'
+        nav_version = '2.9.0'
+        paging_version = '3.3.6'
+        room_version = '2.6.1'
+        timber_version = '5.0.1'
     }
 }
 plugins {
@@ -23,6 +22,6 @@ plugins {
     id 'org.jetbrains.kotlin.android' version '2.2.0' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '2.2.0' apply false
     id 'io.gitlab.arturbosch.detekt' version '1.23.8' apply false
-    id 'com.google.devtools.ksp' version '2.1.21-2.0.1' apply false
+    id 'com.google.devtools.ksp' version '2.2.0-2.0.2' apply false
     id 'org.jetbrains.kotlin.plugin.compose' version '2.2.0' apply false
 }

--- a/samples/MobileBuyIntegration/build.gradle
+++ b/samples/MobileBuyIntegration/build.gradle
@@ -1,23 +1,28 @@
 buildscript {
     ext {
-        app_compat_version = '1.6.1'
+        app_compat_version = '1.7.1'
         core_version = '1.16.0'
-        activity_version = '1.9.0'
+        activity_version = '1.10.1'
+        annotation_version = '1.9.1'
         lifecycle_version = '2.7.0'
         datastore_version = '1.1.1'
-        nav_version = '2.7.7'
+        nav_version = '2.9.0'
         compose_ui_version = '1.8.3'
-        mobile_buy_version = '17.0.0'
-        coil_version = '2.6.0'
-        kotlin_serialization_version = '1.6.3'
-        koin_android_compose_version = '3.5.3'
-        room_version = "2.6.1"
+        mobile_buy_version = '2025.4.1'
+        coil_version = '2.7.0'
+        timber_version = '5.0.1'
+        kotlin_serialization_version = '1.8.1'
+        koin_android_compose_version = '4.1.0'
+        room_version = '2.6.1'
+        paging_version = '3.3.6'
+        material3_version = '1.3.2'
     }
 }
 plugins {
     id 'com.android.application' version '8.11.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.22' apply false
-    id 'io.gitlab.arturbosch.detekt' version '1.23.0' apply false
-    id 'com.google.devtools.ksp' version "1.9.22-1.0.17" apply false
+    id 'org.jetbrains.kotlin.android' version '2.2.0' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.2.0' apply false
+    id 'io.gitlab.arturbosch.detekt' version '1.23.8' apply false
+    id 'com.google.devtools.ksp' version '2.1.21-2.0.1' apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version '2.2.0' apply false
 }

--- a/samples/SimpleCheckout/app/build.gradle
+++ b/samples/SimpleCheckout/app/build.gradle
@@ -49,7 +49,7 @@ android {
     defaultConfig {
         applicationId "com.shopify.checkout_sdk_sample"
         minSdk 23
-        targetSdk 34
+        targetSdk 36
         versionCode 1
         versionName getVersionName()
 

--- a/samples/SimpleCheckout/app/build.gradle
+++ b/samples/SimpleCheckout/app/build.gradle
@@ -2,7 +2,8 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id 'org.jetbrains.kotlin.plugin.serialization'
-    id "com.apollographql.apollo"
+    id 'com.apollographql.apollo'
+    id 'org.jetbrains.kotlin.plugin.compose'
 }
 
 def loadProperties() {

--- a/samples/SimpleCheckout/build.gradle
+++ b/samples/SimpleCheckout/build.gradle
@@ -1,18 +1,19 @@
 buildscript {
     ext {
-        core_version = '1.12.0'
+        core_version = '1.16.0'
         compose_ui_version = '1.8.3'
         lifecycle_version = '2.7.0'
-        activity_version = '1.8.2'
-        coil_version = '2.6.0'
-        kotlin_serialization_version = '1.6.2'
+        activity_version = '1.10.1'
+        coil_version = '2.7.0'
+        kotlin_serialization_version = '1.8.1'
         apollo_version = '4.3.1'
     }
 }
 plugins {
     id 'com.android.application' version '8.11.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.22' apply false
-    id 'io.gitlab.arturbosch.detekt' version '1.23.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.2.0' apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.2.0' apply false
+    id 'io.gitlab.arturbosch.detekt' version '1.23.8' apply false
     id 'com.apollographql.apollo' version '4.3.1' apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version '2.2.0'
 }


### PR DESCRIPTION
### What changes are you making?

Update a number of sample app dependencies in one go

N.B. This brings some sample app versions ahead of the lib (e.g. kotlin & kotlinx serialization versions), which is fine. We can keep some versions in the lib a little lower to ensure better compatibility with various clients.

N.B.2: Encrypted shared prefs is deprecated. So we've switched it out.

N.B.3: Timber was previously depended on transitively though mobile buy, we now explicitly depend on it in the Mobile Buy sample (not the lib)

### How to test

Click around in the sample apps

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
