### PR TITLE
fix gradle assignment deprecations

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,13 +34,13 @@ ext {
 }
 
 android {
-    namespace 'com.shopify.checkoutsheetkit'
-    compileSdk 36
+    namespace = 'com.shopify.checkoutsheetkit'
+    compileSdk = 36
 
     defaultConfig {
-        minSdk 23
-        targetSdk 35
-        versionCode 1
+        minSdk = 23
+        targetSdk = 35
+        versionCode = 1
         versionName
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -48,8 +48,8 @@ android {
     }
 
     lintOptions {
-        checkDependencies true
-        warningsAsErrors true
+        checkDependencies = true
+        warningsAsErrors = true
         warning 'LintBaseline'
     }
 
@@ -81,7 +81,7 @@ android {
         }
     }
     buildFeatures {
-        buildConfig true
+        buildConfig = true
     }
 }
 
@@ -137,9 +137,9 @@ project.afterEvaluate {
                     name = "CheckoutSheetKit"
                     description = "Shopify's Checkout Sheet Kit makes it simple to render checkouts inside your mobile app."
                     url = "https://github.com/Shopify/checkout-sheet-kit-android"
-                    groupId "com.shopify"
-                    artifactId "checkout-sheet-kit"
-                    version versionName
+                    groupId = "com.shopify"
+                    artifactId = "checkout-sheet-kit"
+                    version = versionName
 
                     licenses {
                         license {
@@ -172,8 +172,8 @@ project.afterEvaluate {
                 name = 'ossrh-staging-api'
                 url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
                 credentials {
-                    username System.getenv("OSSRH_USERNAME")
-                    password System.getenv("OSSRH_PASSWORD")
+                    username = System.getenv("OSSRH_USERNAME")
+                    password = System.getenv("OSSRH_PASSWORD")
                 }
             }
         }

--- a/samples/MobileBuyIntegration/app/build.gradle
+++ b/samples/MobileBuyIntegration/app/build.gradle
@@ -36,18 +36,18 @@ if (!storefrontDomain || !accessToken) {
 
 android {
     namespace 'com.shopify.checkout_sdk_mobile_buy_integration_sample'
-    compileSdk 36
+    compileSdk = 36
 
     defaultConfig {
         applicationId "com.shopify.checkout_sdk_mobile_buy_integration_sample"
-        minSdk 28
-        targetSdk 36
-        versionCode 34
-        versionName "0.0.${versionCode}"
+        minSdk = 28
+        targetSdk = 36
+        versionCode = 34
+        versionName = "0.0.${versionCode}"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
-            useSupportLibrary true
+            useSupportLibrary = true
         }
         buildConfigField "String", "storefrontDomain", "\"$storefrontDomain\""
         buildConfigField "String", "storefrontAccessToken", "\"$accessToken\""
@@ -59,20 +59,20 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
         debug {
-            debuggable true
+            debuggable = true
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     buildFeatures {
-        compose true
-        buildConfig true
+        compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion '1.5.8'
@@ -86,7 +86,7 @@ android {
 
 tasks.withType(KotlinJvmCompile).configureEach {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
+        jvmTarget = JvmTarget.JVM_11
     }
 }
 

--- a/samples/SimpleCheckout/app/build.gradle
+++ b/samples/SimpleCheckout/app/build.gradle
@@ -46,42 +46,42 @@ apollo {
 }
 
 android {
-    namespace 'com.shopify.checkout_sdk_sample'
-    compileSdk 36
+    namespace = 'com.shopify.checkout_sdk_sample'
+    compileSdk = 36
 
     defaultConfig {
-        applicationId "com.shopify.checkout_sdk_sample"
-        minSdk 23
-        targetSdk 36
-        versionCode 1
-        versionName getVersionName()
+        applicationId = "com.shopify.checkout_sdk_sample"
+        minSdk = 23
+        targetSdk = 36
+        versionCode = 1
+        versionName = getVersionName()
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
-            useSupportLibrary true
+            useSupportLibrary = true
         }
     }
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled = false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField('String', 'storefrontDomain', '"' + storefrontDomain + '"')
             buildConfigField('String', 'storefrontAccessToken', '"' + accessToken + '"')
         }
         debug {
-            debuggable true
+            debuggable = true
             buildConfigField('String', 'storefrontDomain', '"' + storefrontDomain + '"')
             buildConfigField('String', 'storefrontAccessToken', '"' + accessToken + '"')
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
     buildFeatures {
-        compose true
-        buildConfig true
+        compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion '1.5.8'


### PR DESCRIPTION
### What changes are you making?

Fixes a number of gradle deprecation warnings:

```
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. |  
-- | --
This is scheduled to be removed in Gradle 10.0. |  
Use assignment ('groupId = <value>') instead.
```

### How to test

Run a build 

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have added a [Changelog](https://github.com/shopify/checkout-sheet-kit-android/blob/main/CHANGELOG.md) entry.
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
