### PR TITLE
Replace Sec-Purpose with Shopify-Purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ your project:
 ### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.5.0"
+implementation "com.shopify:checkout-sheet-kit:3.5.1"
 ```
 
 ### Maven
@@ -64,7 +64,7 @@ implementation "com.shopify:checkout-sheet-kit:3.5.0"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.5.0</version>
+   <version>3.5.1</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -15,7 +15,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.5.0")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.5.1")
 
 ext {
     app_compat_version = '1.7.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -106,7 +106,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
         initLoadTime = System.currentTimeMillis()
         this.isPreload = isPreload
         Handler(Looper.getMainLooper()).post {
-            val headers = if (isPreload) mutableMapOf("Sec-Purpose" to "prefetch") else mutableMapOf()
+            val headers = if (isPreload) mutableMapOf("Shopify-Purpose" to "prefetch") else mutableMapOf()
             loadUrl(url, headers)
         }
     }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewTest.kt
@@ -141,7 +141,7 @@ class CheckoutWebViewTest {
             val shadow = shadowOf(view)
             ShadowLooper.shadowMainLooper().runToEndOfTasks()
 
-            assertThat(shadow.lastAdditionalHttpHeaders.getOrDefault("Sec-Purpose", "")).isEqualTo("prefetch")
+            assertThat(shadow.lastAdditionalHttpHeaders.getOrDefault("Shopify-Purpose", "")).isEqualTo("prefetch")
         }
     }
 
@@ -187,7 +187,7 @@ class CheckoutWebViewTest {
         val shadow = shadowOf(view)
         ShadowLooper.shadowMainLooper().runToEndOfTasks()
 
-        assertThat(shadow.lastAdditionalHttpHeaders.getOrDefault("Sec-Purpose", "")).isEqualTo("")
+        assertThat(shadow.lastAdditionalHttpHeaders.getOrDefault("Shopify-Purpose", "")).isEqualTo("")
     }
 
     @Test


### PR DESCRIPTION
### What changes are you making?

Updates Sec-Purpose header which was proving problematic on iOS 26 with a Shopify-Purpose header to keep consistency across platforms.

### How to test

Preload

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [x] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
