### PR TITLE
Emit events from the main thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,34 +10,35 @@
 
 **Note**: We're in the process of renaming "Checkout Sheet Kit" to "Checkout Kit." The dev docs and README already use the new name, while the package itself will be updated in an upcoming version.
 
-- [Requirements](#requirements)
-- [Getting Started](#getting-started)
-  - [Gradle](#gradle)
-  - [Maven](#maven)
-- [Basic Usage](#basic-usage)
-- [Configuration](#configuration)
-  - [Color Scheme](#color-scheme)
-  - [Log Level](#log-level)
-  - [Checkout Dialog Title](#checkout-dialog-title)
-- [Preloading](#preloading)
-  - [Important considerations](#important-considerations)
-  - [Flash Sales](#flash-sales)
-  - [When to preload](#when-to-preload)
-  - [Cache invalidation](#cache-invalidation)
-  - [Lifecycle management for preloaded checkout](#lifecycle-management-for-preloaded-checkout)
-    - [Additional considerations for preloaded checkout](#additional-considerations-for-preloaded-checkout)
-- [Monitoring the lifecycle of a checkout session](#monitoring-the-lifecycle-of-a-checkout-session)
-  - [Error handling](#error-handling)
-    - [`CheckoutException`](#checkoutexception)
-    - [Exception Hierarchy](#exception-hierarchy)
-  - [Integrating with Web Pixels, monitoring behavioral data](#integrating-with-web-pixels-monitoring-behavioral-data)
-- [Integrating identity \& customer accounts](#integrating-identity--customer-accounts)
-  - [Cart: buyer bag, identity, and preferences](#cart-buyer-bag-identity-and-preferences)
-  - [Multipass](#multipass)
-  - [Shop Pay](#shop-pay)
-  - [Customer Account API](#customer-account-api)
-- [Contributing](#contributing)
-- [License](#license)
+- [Shopify Checkout Kit - Android](#shopify-checkout-kit---android)
+  - [Requirements](#requirements)
+  - [Getting Started](#getting-started)
+    - [Gradle](#gradle)
+    - [Maven](#maven)
+  - [Basic Usage](#basic-usage)
+  - [Configuration](#configuration)
+    - [Color Scheme](#color-scheme)
+    - [Log Level](#log-level)
+    - [Checkout Dialog Title](#checkout-dialog-title)
+  - [Preloading](#preloading)
+    - [Important considerations](#important-considerations)
+    - [Flash Sales](#flash-sales)
+    - [When to preload](#when-to-preload)
+    - [Cache invalidation](#cache-invalidation)
+    - [Lifecycle management for preloaded checkout](#lifecycle-management-for-preloaded-checkout)
+      - [Additional considerations for preloaded checkout](#additional-considerations-for-preloaded-checkout)
+  - [Monitoring the lifecycle of a checkout session](#monitoring-the-lifecycle-of-a-checkout-session)
+    - [Error handling](#error-handling)
+      - [`CheckoutException`](#checkoutexception)
+      - [Exception Hierarchy](#exception-hierarchy)
+    - [Integrating with Web Pixels, monitoring behavioral data](#integrating-with-web-pixels-monitoring-behavioral-data)
+  - [Integrating identity \& customer accounts](#integrating-identity--customer-accounts)
+    - [Cart: buyer bag, identity, and preferences](#cart-buyer-bag-identity-and-preferences)
+    - [Multipass](#multipass)
+    - [Shop Pay](#shop-pay)
+    - [Customer Account API](#customer-account-api)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Requirements
 
@@ -54,7 +55,7 @@ your project:
 ### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.5.1"
+implementation "com.shopify:checkout-sheet-kit:3.5.2"
 ```
 
 ### Maven
@@ -64,7 +65,7 @@ implementation "com.shopify:checkout-sheet-kit:3.5.1"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.5.1</version>
+   <version>3.5.2</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,35 +10,34 @@
 
 **Note**: We're in the process of renaming "Checkout Sheet Kit" to "Checkout Kit." The dev docs and README already use the new name, while the package itself will be updated in an upcoming version.
 
-- [Shopify Checkout Kit - Android](#shopify-checkout-kit---android)
-  - [Requirements](#requirements)
-  - [Getting Started](#getting-started)
-    - [Gradle](#gradle)
-    - [Maven](#maven)
-  - [Basic Usage](#basic-usage)
-  - [Configuration](#configuration)
-    - [Color Scheme](#color-scheme)
-    - [Log Level](#log-level)
-    - [Checkout Dialog Title](#checkout-dialog-title)
-  - [Preloading](#preloading)
-    - [Important considerations](#important-considerations)
-    - [Flash Sales](#flash-sales)
-    - [When to preload](#when-to-preload)
-    - [Cache invalidation](#cache-invalidation)
-    - [Lifecycle management for preloaded checkout](#lifecycle-management-for-preloaded-checkout)
-      - [Additional considerations for preloaded checkout](#additional-considerations-for-preloaded-checkout)
-  - [Monitoring the lifecycle of a checkout session](#monitoring-the-lifecycle-of-a-checkout-session)
-    - [Error handling](#error-handling)
-      - [`CheckoutException`](#checkoutexception)
-      - [Exception Hierarchy](#exception-hierarchy)
-    - [Integrating with Web Pixels, monitoring behavioral data](#integrating-with-web-pixels-monitoring-behavioral-data)
-  - [Integrating identity \& customer accounts](#integrating-identity--customer-accounts)
-    - [Cart: buyer bag, identity, and preferences](#cart-buyer-bag-identity-and-preferences)
-    - [Multipass](#multipass)
-    - [Shop Pay](#shop-pay)
-    - [Customer Account API](#customer-account-api)
-  - [Contributing](#contributing)
-  - [License](#license)
+- [Requirements](#requirements)
+- [Getting Started](#getting-started)
+  - [Gradle](#gradle)
+  - [Maven](#maven)
+- [Basic Usage](#basic-usage)
+- [Configuration](#configuration)
+  - [Color Scheme](#color-scheme)
+  - [Log Level](#log-level)
+  - [Checkout Dialog Title](#checkout-dialog-title)
+- [Preloading](#preloading)
+  - [Important considerations](#important-considerations)
+  - [Flash Sales](#flash-sales)
+  - [When to preload](#when-to-preload)
+  - [Cache invalidation](#cache-invalidation)
+  - [Lifecycle management for preloaded checkout](#lifecycle-management-for-preloaded-checkout)
+    - [Additional considerations for preloaded checkout](#additional-considerations-for-preloaded-checkout)
+- [Monitoring the lifecycle of a checkout session](#monitoring-the-lifecycle-of-a-checkout-session)
+  - [Error handling](#error-handling)
+    - [`CheckoutException`](#checkoutexception)
+    - [Exception Hierarchy](#exception-hierarchy)
+  - [Integrating with Web Pixels, monitoring behavioral data](#integrating-with-web-pixels-monitoring-behavioral-data)
+- [Integrating identity \& customer accounts](#integrating-identity--customer-accounts)
+  - [Cart: buyer bag, identity, and preferences](#cart-buyer-bag-identity-and-preferences)
+  - [Multipass](#multipass)
+  - [Shop Pay](#shop-pay)
+  - [Customer Account API](#customer-account-api)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Requirements
 
@@ -187,7 +186,7 @@ ShopifyCheckoutSheetKit.configure {
     it.colorScheme = ColorScheme.Light().customize {
         // Option 1: Just tint the default close icon
         closeIconTint = Color.ResourceId(R.color.my_custom_tint_color)
-        
+
         // Option 2: Use a completely custom drawable
         closeIcon = DrawableResource(R.drawable.my_custom_close_icon)
     }
@@ -440,21 +439,21 @@ ShopifyCheckoutSheetKit.configure {
 
 #### `CheckoutException`
 
-| Exception Class                | Error Code                     | Description                                                                   | Recommendation                                                                                    |
-| ------------------------------ | ------------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `ConfigurationException`       | 'checkout_liquid_not_migrated' | `checkout.liquid` is not supported.                                           | Upgrade to Extensibility.                                                                         |
-| `ConfigurationException`       | 'storefront_password_required' | Access to checkout is password protected.                                     | We are working on ways to enable the Checkout Kit for usage with password protected stores. |
-| `ConfigurationException`       | 'unknown'                      | Other configuration issue, see error details for more info.                   | Resolve the configuration issue in the error message.                                             |
-| `CheckoutExpiredException`     | 'cart_expired'                 | The cart or checkout is no longer available.                                  | Create a new cart and open a new checkout URL.                                                    |
-| `CheckoutExpiredException`     | 'cart_completed'               | The cart associated with the checkout has completed checkout.                 | Create new cart and open a new checkout URL.                                                      |
-| `CheckoutExpiredException`     | 'invalid_cart'                 | The cart associated with the checkout is invalid (e.g. empty).                | Create a new cart and open a new checkout URL.                                                    |
-| `CheckoutSheetKitException`    | 'error_receiving_message'      | Checkout Kit failed to receive a message from checkout.                 | Show checkout in a fallback WebView.                                                              |
-| `CheckoutSheetKitException`    | 'error_sending_message'        | Checkout Kit failed to send a message to checkout.                      | Show checkout in a fallback WebView.                                                              |
-| `CheckoutSheetKitException`    | 'render_process_gone'          | The render process for the checkout WebView is gone.                          | Show checkout in a fallback WebView.                                                              |
-| `CheckoutSheetKitException`    | 'unknown'                      | An error in Checkout Kit has occurred, see error details for more info. | Show checkout in a fallback WebView.                                                              |
-| `HttpException`                | 'http_error'                   | An unexpected server error has been encountered.                              | Show checkout in a fallback WebView.                                                              |
-| `ClientException`              | 'client_error'                 | An unhandled client error was encountered.                                    | Show checkout in a fallback WebView.                                                              |
-| `CheckoutUnavailableException` | 'unknown'                      | Checkout is unavailable for another reason, see error details for more info.  | Show checkout in a fallback WebView.                                                              |
+| Exception Class                | Error Code                     | Description                                                                  | Recommendation                                                                              |
+| ------------------------------ | ------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `ConfigurationException`       | 'checkout_liquid_not_migrated' | `checkout.liquid` is not supported.                                          | Upgrade to Extensibility.                                                                   |
+| `ConfigurationException`       | 'storefront_password_required' | Access to checkout is password protected.                                    | We are working on ways to enable the Checkout Kit for usage with password protected stores. |
+| `ConfigurationException`       | 'unknown'                      | Other configuration issue, see error details for more info.                  | Resolve the configuration issue in the error message.                                       |
+| `CheckoutExpiredException`     | 'cart_expired'                 | The cart or checkout is no longer available.                                 | Create a new cart and open a new checkout URL.                                              |
+| `CheckoutExpiredException`     | 'cart_completed'               | The cart associated with the checkout has completed checkout.                | Create new cart and open a new checkout URL.                                                |
+| `CheckoutExpiredException`     | 'invalid_cart'                 | The cart associated with the checkout is invalid (e.g. empty).               | Create a new cart and open a new checkout URL.                                              |
+| `CheckoutSheetKitException`    | 'error_receiving_message'      | Checkout Kit failed to receive a message from checkout.                      | Show checkout in a fallback WebView.                                                        |
+| `CheckoutSheetKitException`    | 'error_sending_message'        | Checkout Kit failed to send a message to checkout.                           | Show checkout in a fallback WebView.                                                        |
+| `CheckoutSheetKitException`    | 'render_process_gone'          | The render process for the checkout WebView is gone.                         | Show checkout in a fallback WebView.                                                        |
+| `CheckoutSheetKitException`    | 'unknown'                      | An error in Checkout Kit has occurred, see error details for more info.      | Show checkout in a fallback WebView.                                                        |
+| `HttpException`                | 'http_error'                   | An unexpected server error has been encountered.                             | Show checkout in a fallback WebView.                                                        |
+| `ClientException`              | 'client_error'                 | An unhandled client error was encountered.                                   | Show checkout in a fallback WebView.                                                        |
+| `CheckoutUnavailableException` | 'unknown'                      | Checkout is unavailable for another reason, see error details for more info. | Show checkout in a fallback WebView.                                                        |
 
 #### Exception Hierarchy
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -15,7 +15,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.5.1")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.5.2")
 
 ext {
     app_compat_version = '1.7.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutBridge.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutBridge.kt
@@ -81,7 +81,9 @@ internal class CheckoutBridge(
                     log.d(LOG_TAG, "Received Completed message.  Attempting to decode.")
                     checkoutCompletedEventDecoder.decode(decodedMsg).let { event ->
                         log.d(LOG_TAG, "Decoded message $event.")
-                        eventProcessor.onCheckoutViewComplete(event)
+                        onMainThread {
+                            eventProcessor.onCheckoutViewComplete(event)
+                        }
                     }
                 }
 
@@ -90,7 +92,9 @@ internal class CheckoutBridge(
                     val modalVisible = decodedMsg.body.toBooleanStrictOrNull()
                     modalVisible?.let {
                         log.d(LOG_TAG, "Modal visible $it")
-                        eventProcessor.onCheckoutViewModalToggled(modalVisible)
+                        onMainThread {
+                            eventProcessor.onCheckoutViewModalToggled(modalVisible)
+                        }
                     }
                 }
 
@@ -98,7 +102,9 @@ internal class CheckoutBridge(
                     log.d(LOG_TAG, "Received WebPixel message. Attempting to decode.")
                     pixelEventDecoder.decode(decodedMsg)?.let { event ->
                         log.d(LOG_TAG, "Decoded message $event.")
-                        eventProcessor.onWebPixelEvent(event)
+                        onMainThread {
+                            eventProcessor.onWebPixelEvent(event)
+                        }
                     }
                 }
 
@@ -106,7 +112,9 @@ internal class CheckoutBridge(
                     log.d(LOG_TAG, "Received Error message. Attempting to decode.")
                     checkoutErrorDecoder.decode(decodedMsg)?.let { exception ->
                         log.d(LOG_TAG, "Decoded message $exception.")
-                        eventProcessor.onCheckoutViewFailedWithError(exception)
+                        onMainThread {
+                            eventProcessor.onCheckoutViewFailedWithError(exception)
+                        }
                     }
                 }
 
@@ -114,13 +122,15 @@ internal class CheckoutBridge(
             }
         } catch (e: Exception) {
             log.d(LOG_TAG, "Failed to decode message with error: $e. Calling onCheckoutFailedWithError")
-            eventProcessor.onCheckoutViewFailedWithError(
-                CheckoutSheetKitException(
-                    errorDescription = "Error decoding message from checkout.",
-                    errorCode = CheckoutSheetKitException.ERROR_RECEIVING_MESSAGE_FROM_CHECKOUT,
-                    isRecoverable = true,
-                ),
-            )
+            onMainThread {
+                eventProcessor.onCheckoutViewFailedWithError(
+                    CheckoutSheetKitException(
+                        errorDescription = "Error decoding message from checkout.",
+                        errorCode = CheckoutSheetKitException.ERROR_RECEIVING_MESSAGE_FROM_CHECKOUT,
+                        isRecoverable = true,
+                    ),
+                )
+            }
         }
     }
 
@@ -143,13 +153,15 @@ internal class CheckoutBridge(
             view.evaluateJavascript(script, null)
         } catch (e: Exception) {
             log.d(LOG_TAG, "Failed to send message to checkout, invoking onCheckoutViewFailedWithError")
-            eventProcessor.onCheckoutViewFailedWithError(
-                CheckoutSheetKitException(
-                    errorDescription = "Failed to send '${operation.key}' message to checkout, some features may not work.",
-                    errorCode = CheckoutSheetKitException.ERROR_SENDING_MESSAGE_TO_CHECKOUT,
-                    isRecoverable = true,
+            onMainThread {
+                eventProcessor.onCheckoutViewFailedWithError(
+                    CheckoutSheetKitException(
+                        errorDescription = "Failed to send '${operation.key}' message to checkout, some features may not work.",
+                        errorCode = CheckoutSheetKitException.ERROR_SENDING_MESSAGE_TO_CHECKOUT,
+                        isRecoverable = true,
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
@@ -23,8 +23,6 @@
 package com.shopify.checkoutsheetkit
 
 import android.net.Uri
-import android.os.Handler
-import android.os.Looper
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import android.webkit.GeolocationPermissions
@@ -115,12 +113,6 @@ internal class CheckoutWebViewEventProcessor(
     fun onWebPixelEvent(event: PixelEvent) {
         log.d(LOG_TAG, "Calling onWebPixelEvent for $event.")
         eventProcessor.onWebPixelEvent(event)
-    }
-
-    private fun onMainThread(block: () -> Unit) {
-        Handler(Looper.getMainLooper()).post {
-            block()
-        }
     }
 
     companion object {

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/ThreadExtensions.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/ThreadExtensions.kt
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkoutsheetkit
+
+import android.os.Handler
+import android.os.Looper
+
+/**
+ * Executes the given block on the main (UI) thread.
+ * If already on the main thread, executes immediately.
+ * Otherwise, posts to the main thread handler.
+ */
+internal fun onMainThread(block: () -> Unit) {
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+        block()
+    } else {
+        Handler(Looper.getMainLooper()).post {
+            block()
+        }
+    }
+}

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/ThreadExtensionsTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/ThreadExtensionsTest.kt
@@ -1,0 +1,76 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkoutsheetkit
+
+import android.os.Looper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(RobolectricTestRunner::class)
+@LooperMode(LooperMode.Mode.PAUSED)
+class ThreadExtensionsTest {
+
+    @Test
+    fun `onMainThread executes immediately when already on main thread`() {
+        var executed = false
+        onMainThread { 
+            executed = true 
+            assertThat(Looper.myLooper()).isEqualTo(Looper.getMainLooper())
+        }
+        assertThat(executed).isTrue()
+    }
+
+    @Test
+    fun `onMainThread posts to main looper when called from background thread`() {
+        var executedOnMainThread: Boolean? = null
+        val shadowLooper = ShadowLooper.shadowMainLooper()
+        
+        // Verify no tasks are initially queued
+        assertThat(shadowLooper.isIdle).isTrue()
+        
+        // Create background thread and call onMainThread from it
+        val thread = Thread {
+            onMainThread {
+                executedOnMainThread = Looper.myLooper() == Looper.getMainLooper()
+            }
+        }
+        thread.start()
+        thread.join() // Wait for thread to complete
+        
+        // Task should be queued on main looper but not yet executed
+        assertThat(shadowLooper.isIdle).isFalse()
+        assertThat(executedOnMainThread).isNull()
+        
+        // Run pending tasks on main looper  
+        shadowLooper.runToEndOfTasks()
+        
+        // Now callback should have executed on main thread
+        assertThat(executedOnMainThread).isNotNull()
+        assertThat(executedOnMainThread).isTrue()
+        assertThat(shadowLooper.isIdle).isTrue()
+    }
+}


### PR DESCRIPTION
### What changes are you making?

We've received a couple of reports around errors being observed when receiving events:

`Methods marked with @UiThread must be executed on the main thread. Current thread: JavaBridge. Calling onCheckoutFailedWithError`

This was because `CheckoutBridge.postMessage()` (called from the JavaScript bridge on the "JavaBridge" thread) was directly calling event processor methods in some cases.

As a solution:
  - Created ThreadExtensions.kt with a reusable onMainThread() utility function
  - Updated CheckoutBridge to wrap all event processor calls with onMainThread {}
  - Refactored CheckoutWebViewEventProcessor to use the shared utility instead of duplicate code

 The onMainThread() function:
  - Executes immediately if already on the main thread (no performance impact for main thread usage)
  - Posts to main thread handler if called from background threads
  - Follows existing project patterns (similar to UriExtensions.kt)

This also matches up with the swift repo, where events should be emitted from the main thread

### How to test

You can add this to `MobileBuyEventProcessor#onCheckoutCompleted`

```kotlin
check(Looper.myLooper() == Looper.getMainLooper()) { 
    "onCheckoutCompleted must be called on main thread. Current thread: ${Thread.currentThread().name}" 
}
```

Alternatively
```kotlin
check(Thread.currentThread().name != "JavaBridge") {
    "onCheckoutCompleted must be called on main thread. Current thread: ${Thread.currentThread().name}" 
}
```

And comment `onMainThread` in CheckoutBridge
```kotlin
//onMainThread {
   eventProcessor.onCheckoutViewComplete(event)
//}
```

Complete a checkout -> observe checkout failed message
Uncomment `onMainThread`, and repeat -> observe no checkout failed message

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [x] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
