### PR TITLE
Specify Chrome >= 80 as minimum requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 
 - JDK 17+
 - Android SDK 23+
+- Chrome >= 80
 
 ## Getting Started
 


### PR DESCRIPTION
### What changes are you making?

Thought checkout _may_ work for some stores on versions of Chrome less than 80, it works most consistently on >= 80. This includes payment experiences like Shop Pay. 

We do not recommend users use versions of Chrome lower than this.

Chrome 80 is supported on Android SDK version 21 onwards.

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
