### PR TITLE
Remove outdated liquid reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ your project:
 ### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.5.2"
+implementation "com.shopify:checkout-sheet-kit:3.5.3"
 ```
 
 ### Maven
@@ -64,7 +64,7 @@ implementation "com.shopify:checkout-sheet-kit:3.5.2"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.5.2</version>
+   <version>3.5.3</version>
 </dependency>
 ```
 
@@ -441,7 +441,6 @@ ShopifyCheckoutSheetKit.configure {
 
 | Exception Class                | Error Code                     | Description                                                                  | Recommendation                                                                              |
 | ------------------------------ | ------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `ConfigurationException`       | 'checkout_liquid_not_migrated' | `checkout.liquid` is not supported.                                          | Upgrade to Extensibility.                                                                   |
 | `ConfigurationException`       | 'storefront_password_required' | Access to checkout is password protected.                                    | We are working on ways to enable the Checkout Kit for usage with password protected stores. |
 | `ConfigurationException`       | 'unknown'                      | Other configuration issue, see error details for more info.                  | Resolve the configuration issue in the error message.                                       |
 | `CheckoutExpiredException`     | 'cart_expired'                 | The cart or checkout is no longer available.                                 | Create a new cart and open a new checkout URL.                                              |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@
 
 - JDK 17+
 - Android SDK 23+
-- The SDK is not compatible with checkout.liquid. The Shopify Store must be migrated for extensibility
 
 ## Getting Started
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -15,7 +15,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.5.2")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.5.3")
 
 ext {
     app_compat_version = '1.7.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -184,7 +184,6 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
                     request,
                     errorResponse.statusCode,
                     errorResponse.reasonPhrase.ifBlank { "HTTP ${errorResponse.statusCode} Error" },
-                    errorResponse.responseHeaders,
                 )
             }
         }
@@ -202,7 +201,6 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
             request: WebResourceRequest?,
             errorCode: Int,
             errorDescription: String,
-            responseHeaders: MutableMap<String, String> = mutableMapOf(),
         ) {
             if (request?.isForMainFrame == true) {
                 log.d(
@@ -211,18 +209,6 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
                 )
                 val processor = getEventProcessor()
                 when {
-                    errorCode == HTTP_NOT_FOUND && responseHeaders[DEPRECATED_REASON_HEADER]?.lowercase() == LIQUID_NOT_SUPPORTED -> {
-                        log.d(LOG_TAG, "Failing with liquid not supported error. Recoverable: false")
-                        processor.onCheckoutViewFailedWithError(
-                            ConfigurationException(
-                                errorDescription = "Storefronts using checkout.liquid are not supported. Please upgrade to Checkout " +
-                                    "Extensibility.",
-                                errorCode = ConfigurationException.CHECKOUT_LIQUID_NOT_MIGRATED,
-                                isRecoverable = false,
-                            )
-                        )
-                    }
-
                     errorCode == HTTP_GONE -> {
                         log.d(LOG_TAG, "Failing with cart expired. Recoverable: false")
                         processor.onCheckoutViewFailedWithError(
@@ -251,9 +237,6 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
 
     companion object {
         private const val LOG_TAG = "BaseWebView"
-        private const val DEPRECATED_REASON_HEADER = "X-Shopify-API-Deprecated-Reason"
-        private const val LIQUID_NOT_SUPPORTED = "checkout_liquid_not_supported"
-
         private const val TOO_MANY_REQUESTS = 429
         private val CLIENT_ERROR = 400..499
     }

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutException.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutException.kt
@@ -117,7 +117,6 @@ public class ConfigurationException @JvmOverloads constructor(
     isRecoverable: Boolean,
 ) : CheckoutException(errorDescription ?: "Checkout is unavailable due to a configuration issue.", errorCode, isRecoverable) {
         public companion object {
-            public const val CHECKOUT_LIQUID_NOT_MIGRATED: String = "checkout_liquid_not_migrated"
             public const val STOREFRONT_PASSWORD_REQUIRED: String = "storefront_password_required"
             public const val UNKNOWN: String = "unknown"
         }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
@@ -178,25 +178,6 @@ class CheckoutWebViewClientTest {
     }
 
     @Test
-    fun `should call event processor calls onCheckoutViewFailedWithError on http error for main frame - 404 and deprecated header`() {
-        val mockRequest = mockWebRequest(Uri.parse("https://checkout-sdk.myshopify.com"), true)
-        val mockResponse = mockWebResourceResponse(
-            status = HttpURLConnection.HTTP_NOT_FOUND,
-            headers = mutableMapOf("X-Shopify-API-Deprecated-Reason" to "checkout_liquid_not_supported")
-        )
-
-        triggerOnReceivedHttpError(mockRequest, mockResponse)
-
-        val captor = argumentCaptor<CheckoutException>()
-        verify(checkoutWebViewEventProcessor).onCheckoutViewFailedWithError(captor.capture())
-        assertThat(captor.firstValue)
-            .isInstanceOf(ConfigurationException::class.java)
-            .isNotRecoverable()
-            .hasErrorCode(ConfigurationException.CHECKOUT_LIQUID_NOT_MIGRATED)
-            .hasDescription("Storefronts using checkout.liquid are not supported. Please upgrade to Checkout Extensibility.")
-    }
-
-    @Test
     fun `should call event processor calls onCheckoutViewFailedWithError on http error for main frame - 500`() {
         val mockRequest = mockWebRequest(Uri.parse("https://checkout-sdk.myshopify.com"), true)
         val mockResponse = mockWebResourceResponse(


### PR DESCRIPTION
### What changes are you making?

Removes references to checkout.liquid which has since been deprecated.

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
