### PR TITLE
Fix: Handle intent:// deep links in checkout

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutEventProcessor.kt
@@ -206,11 +206,19 @@ public abstract class DefaultCheckoutEventProcessor @JvmOverloads constructor(
     @SuppressLint("QueryPermissionsNeeded")
     private fun Context.tryLaunchDeepLink(uri: Uri) {
         log.d(LOG_TAG, "Attempting to launch deep link for uri $uri.")
-        val intent = Intent(Intent.ACTION_VIEW)
-        intent.data = uri
-        if (context.packageManager.queryIntentActivities(intent, 0).isNotEmpty()) {
+
+        val intent = try {
+            // ⚠️ Parse intent://...#Intent;...;end;
+            Intent.parseUri(uri.toString(), Intent.URI_INTENT_SCHEME)
+        } catch (e: Exception) {
+            log.e(TAG, "Failed to parse deep link intent: $uri", e)
+            return
+        }
+
+        try {
             startActivity(intent)
-        } else {
+        } catch (e: Exception) {
+            log.e(TAG, "Failed to start activity for deep link: $uri", e)
             log.w(TAG, "Unrecognized scheme for link clicked in checkout '$uri'")
         }
     }


### PR DESCRIPTION
## Summary

- Fixes deep link handling for `intent://` scheme URIs in `CheckoutEventProcessor`
- Uses `Intent.parseUri()` with `URI_INTENT_SCHEME` to properly parse `intent://...#Intent;...;end;` URIs instead of treating them as plain `ACTION_VIEW` intents
- Adds proper error handling with logging for both intent parsing and activity launch failures

## Context

The current implementation creates a basic `ACTION_VIEW` intent for all deep links, which doesn't handle Android's `intent://` URI scheme. This scheme is commonly used by payment providers (e.g., open banking apps) to launch specific activities. By using `Intent.parseUri()`, the SDK can now correctly resolve and launch these intents.

## Test plan

- [x] Verify standard `https://` deep links still work correctly
- [x] Test with `intent://` scheme URIs from payment providers (open banking flows)
- [x] Verify error logging when an unresolvable intent is encountered

🤖 Generated with [Claude Code](https://claude.com/claude-code)