### PR TITLE
Skip recovery after checkout completed

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -205,13 +205,20 @@ internal class CheckoutDialog(
                 "within retry limit?: $isWithinRetryLimit (attempt $recoveryAttemptCount of $MAX_RECOVERY_ATTEMPTS), " +
                 "checkout completed?: $checkoutCompleted.",
         )
-        if (!isOneTimeUseUrl && shouldRecover && isWithinRetryLimit && !checkoutCompleted) {
-            log.d(LOG_TAG, "Attempting to recover from error.")
-            attemptToRecoverFromError(exception)
-        } else {
+        if (isOneTimeUseUrl || checkoutCompleted) {
             log.d(LOG_TAG, "Not attempting to recover, dismissing sheet.")
             dismiss()
+            return
         }
+
+        if (!shouldRecover || !isWithinRetryLimit) {
+            log.d(LOG_TAG, "Not attempting to recover, dismissing sheet.")
+            dismiss()
+            return
+        }
+
+        log.d(LOG_TAG, "Attempting to recover from error.")
+        attemptToRecoverFromError(exception)
     }
 
     internal fun attemptToRecoverFromError(exception: CheckoutException): Boolean {

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -57,6 +57,7 @@ internal class CheckoutDialog(
 ) : Dialog(context) {
 
     internal var recoveryAttemptCount = 0
+    internal var checkoutCompleted = false
 
     fun start(context: ComponentActivity) {
         log.d(LOG_TAG, "Dialog start called.")
@@ -201,9 +202,10 @@ internal class CheckoutDialog(
         log.d(
             LOG_TAG,
             "One time use checkout URL?: $isOneTimeUseUrl, should recover?: $shouldRecover, " +
-                "within retry limit?: $isWithinRetryLimit (attempt $recoveryAttemptCount of $MAX_RECOVERY_ATTEMPTS).",
+                "within retry limit?: $isWithinRetryLimit (attempt $recoveryAttemptCount of $MAX_RECOVERY_ATTEMPTS), " +
+                "checkout completed?: $checkoutCompleted.",
         )
-        if (!isOneTimeUseUrl && shouldRecover && isWithinRetryLimit) {
+        if (!isOneTimeUseUrl && shouldRecover && isWithinRetryLimit && !checkoutCompleted) {
             log.d(LOG_TAG, "Attempting to recover from error.")
             attemptToRecoverFromError(exception)
         } else {
@@ -236,6 +238,7 @@ internal class CheckoutDialog(
             closeCheckoutDialogWithError = ::closeCheckoutDialogWithError,
             setProgressBarVisibility = ::setProgressBarVisibility,
             updateProgressBarPercentage = ::updateProgressBarPercentage,
+            onCheckoutCompleteInternal = { checkoutCompleted = true },
         )
     }
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebViewEventProcessor.kt
@@ -44,10 +44,13 @@ internal class CheckoutWebViewEventProcessor(
     private val closeCheckoutDialogWithError: (CheckoutException) -> Unit = { CheckoutWebView.clearCache() },
     private val setProgressBarVisibility: (Int) -> Unit = {},
     private val updateProgressBarPercentage: (Int) -> Unit = {},
+    private val onCheckoutCompleteInternal: () -> Unit = {},
 ) {
     fun onCheckoutViewComplete(checkoutCompletedEvent: CheckoutCompletedEvent) {
         log.d(LOG_TAG, "Clearing WebView cache after checkout completion.")
         CheckoutWebView.markCacheEntryStale()
+
+        onCheckoutCompleteInternal()
 
         log.d(LOG_TAG, "Calling onCheckoutCompleted $checkoutCompletedEvent.")
         eventProcessor.onCheckoutCompleted(checkoutCompletedEvent)

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
@@ -339,6 +339,25 @@ class CheckoutDialogTest {
     }
 
     @Test
+    fun `closeCheckoutDialogWithError does not recover after checkout completed`() {
+        val mockEventProcessor = mock<DefaultCheckoutEventProcessor>()
+        ShopifyCheckoutSheetKit.present("https://shopify.com", activity, mockEventProcessor)
+
+        val checkoutDialog = ShadowDialog.getLatestDialog() as CheckoutDialog
+        assertThat(checkoutDialog.containsChildOfType(CheckoutWebView::class.java)).isTrue()
+
+        // Simulate checkout completing before an error arrives
+        checkoutDialog.checkoutCompleted = true
+
+        // Recoverable error should NOT trigger recovery since checkout already completed
+        checkoutDialog.closeCheckoutDialogWithError(checkoutException(isRecoverable = true))
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        assertThat(checkoutDialog.containsChildOfType(FallbackWebView::class.java)).isFalse()
+        assertThat(checkoutDialog.isShowing).isFalse()
+    }
+
+    @Test
     fun `closeCheckoutDialogWithError increments recovery attempt count`() {
         val mockEventProcessor = mock<DefaultCheckoutEventProcessor>()
         ShopifyCheckoutSheetKit.present("https://shopify.com", activity, mockEventProcessor)


### PR DESCRIPTION
When checkout completes successfully, set a checkoutCompleted flag via a callback from CheckoutWebViewEventProcessor to CheckoutDialog. If a network error subsequently triggers the recovery flow, the flag prevents a futile recovery attempt against a cart that has already been consumed by the completed order.

Without this guard, the recovery flow loads the original cart URL, gets a 404 (cart no longer exists), and shows the buyer an error for a checkout that actually succeeded.

### What changes are you making?

<!-- Please describe why you are making these changes -->

### How to test

<!-- Please outline the steps to test your changes -->

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
