### PR TITLE
fix swipe back on TYP

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -115,13 +115,15 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_BACK && canGoBack()) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && canGoBack() && !isOnConfirmationPage()) {
             log.d(LOG_TAG, "Back key event detected, navigating back.")
             goBack()
             return true
         }
         return super.onKeyDown(keyCode, event)
     }
+
+    private fun isOnConfirmationPage(): Boolean = url?.let(Uri::parse).isConfirmationPage()
 
     internal fun userAgentSuffix(): String {
         val theme = ShopifyCheckoutSheetKit.configuration.colorScheme.id

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -28,7 +28,6 @@ import android.graphics.Color.TRANSPARENT
 import android.net.Uri
 import android.os.Build
 import android.util.AttributeSet
-import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
@@ -114,13 +113,13 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
         id = View.generateViewId()
     }
 
-    override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_BACK && canGoBack() && !isOnConfirmationPage()) {
-            log.d(LOG_TAG, "Back key event detected, navigating back.")
+    internal fun handleBackPressed(): Boolean {
+        if (canGoBack() && !isOnConfirmationPage()) {
+            log.d(LOG_TAG, "Back navigation handled by WebView history.")
             goBack()
             return true
         }
-        return super.onKeyDown(keyCode, event)
+        return false
     }
 
     private fun isOnConfirmationPage(): Boolean = url?.let(Uri::parse).isConfirmationPage()

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutDialog.kt
@@ -22,7 +22,6 @@
  */
 package com.shopify.checkoutsheetkit
 
-import android.app.Dialog
 import android.content.Context
 import android.content.res.ColorStateList
 import android.content.res.Configuration.UI_MODE_NIGHT_MASK
@@ -42,6 +41,8 @@ import android.webkit.WebView
 import android.widget.ProgressBar
 import android.widget.RelativeLayout
 import androidx.activity.ComponentActivity
+import androidx.activity.ComponentDialog
+import androidx.activity.OnBackPressedCallback
 import androidx.annotation.ColorInt
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.Toolbar
@@ -54,9 +55,20 @@ internal class CheckoutDialog(
     private val checkoutUrl: String,
     private val checkoutEventProcessor: CheckoutEventProcessor,
     context: Context,
-) : Dialog(context) {
+) : ComponentDialog(context) {
 
     internal var recoveryAttemptCount = 0
+
+    private val backNavigationCallback = object : OnBackPressedCallback(enabled = true) {
+        override fun handleOnBackPressed() {
+            val webView = findViewById<RelativeLayout>(R.id.checkoutSdkContainer)
+                ?.children?.firstOrNull { it is BaseWebView } as? BaseWebView
+            if (webView?.handleBackPressed() != true) {
+                log.d(LOG_TAG, "Back press not handled by WebView, cancelling dialog.")
+                cancel()
+            }
+        }
+    }
 
     fun start(context: ComponentActivity) {
         log.d(LOG_TAG, "Dialog start called.")
@@ -100,6 +112,7 @@ internal class CheckoutDialog(
         }
 
         addWebViewToContainer(colorScheme, checkoutWebView)
+        onBackPressedDispatcher.addCallback(backNavigationCallback)
         setOnCancelListener {
             log.d(LOG_TAG, "Cancel listener invoked, invoking onCheckoutCanceled.")
             CheckoutWebViewContainer.retainCacheEntry = RetainCacheEntry.IF_NOT_STALE

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/FallbackWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/FallbackWebView.kt
@@ -56,8 +56,6 @@ internal class FallbackWebView(context: Context, attributeSet: AttributeSet? = n
 
     inner class FallbackWebViewClient : BaseWebView.BaseWebViewClient() {
 
-        private val typRegex = Regex(pattern = "^(thank[-_]+you)$", option = RegexOption.IGNORE_CASE)
-
         init {
             if (BuildConfig.DEBUG) {
                 log.d(LOG_TAG, "Setting web contents debugging enabled.")
@@ -71,7 +69,7 @@ internal class FallbackWebView(context: Context, attributeSet: AttributeSet? = n
             getEventProcessor().onCheckoutViewLoadComplete()
 
             val uri = url.toUri()
-            if (isConfirmation(uri)) {
+            if (uri.isConfirmationPage()) {
                 log.d(LOG_TAG, "Finished page has confirmationUrl. Emitting minimal checkout completed event.")
                 getEventProcessor().onCheckoutViewComplete(
                     emptyCompletedEvent(id = getOrderIdFromQueryString(uri))
@@ -80,7 +78,6 @@ internal class FallbackWebView(context: Context, attributeSet: AttributeSet? = n
         }
 
         private fun getOrderIdFromQueryString(uri: Uri): String? = uri.getQueryParameter("order_id")
-        private fun isConfirmation(uri: Uri) = uri.pathSegments.any { pathSegment -> typRegex.matches(pathSegment) }
     }
 
     companion object {

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/UriExtensions.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/UriExtensions.kt
@@ -1,4 +1,4 @@
-/*
+ /*
  * MIT License
  *
  * Copyright 2023-present, Shopify Inc.
@@ -30,7 +30,11 @@ internal fun Uri?.isTelLink(): Boolean = this?.scheme == Scheme.TEL
 internal fun Uri?.isAboutScheme(): Boolean = this?.scheme == Scheme.ABOUT
 internal fun Uri?.isContactLink(): Boolean = this.isMailtoLink() || this.isTelLink()
 internal fun Uri?.isDeepLink(): Boolean = this != null && !this.isWebLink() && !this.isContactLink() && !this.isAboutScheme()
+internal fun Uri?.isConfirmationPage(): Boolean =
+    this?.pathSegments?.any { CONFIRMATION_PATH_REGEX.matches(it) } == true
 internal fun String.isOneTimeUse(): Boolean = this.contains("multipass")
+
+private val CONFIRMATION_PATH_REGEX = Regex(pattern = "^(thank[-_]+you)$", option = RegexOption.IGNORE_CASE)
 
 internal object Scheme {
     const val HTTP = "http"

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/UriExtensions.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/UriExtensions.kt
@@ -1,4 +1,4 @@
- /*
+/*
  * MIT License
  *
  * Copyright 2023-present, Shopify Inc.

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutDialogTest.kt
@@ -540,6 +540,64 @@ class CheckoutDialogTest {
         // Custom icon should be applied, tint should be ignored
     }
 
+    @Test
+    fun `back press cancels dialog when WebView has no history to navigate`() {
+        val mockEventProcessor = mock<DefaultCheckoutEventProcessor>()
+        ShopifyCheckoutSheetKit.present("https://shopify.com", activity, mockEventProcessor)
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        val dialog = ShadowDialog.getLatestDialog() as CheckoutDialog
+        dialog.onBackPressedDispatcher.onBackPressed()
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        verify(mockEventProcessor).onCheckoutCanceled()
+        assertThat(dialog.isShowing).isFalse()
+    }
+
+    @Test
+    fun `back press navigates WebView history when history exists and not on confirmation page`() {
+        val mockEventProcessor = mock<DefaultCheckoutEventProcessor>()
+        ShopifyCheckoutSheetKit.present("https://shopify.com/checkouts/c/abc", activity, mockEventProcessor)
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        val dialog = ShadowDialog.getLatestDialog() as CheckoutDialog
+        val webView = dialog.currentWebView()
+        webView.loadUrl("https://shopify.com/checkouts/c/abc/step2")
+        shadowOf(webView).setCanGoBack(true)
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        dialog.onBackPressedDispatcher.onBackPressed()
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        verify(mockEventProcessor, never()).onCheckoutCanceled()
+        assertThat(dialog.isShowing).isTrue()
+        assertThat(shadowOf(webView).goBackInvocations).isGreaterThan(0)
+    }
+
+    @Test
+    fun `back press cancels dialog when on confirmation page even with history`() {
+        val mockEventProcessor = mock<DefaultCheckoutEventProcessor>()
+        ShopifyCheckoutSheetKit.present("https://shopify.com/checkouts/c/abc", activity, mockEventProcessor)
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        val dialog = ShadowDialog.getLatestDialog() as CheckoutDialog
+        val webView = dialog.currentWebView()
+        webView.loadUrl("https://shopify.com/cn-12345/thank-you")
+        shadowOf(webView).setCanGoBack(true)
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        dialog.onBackPressedDispatcher.onBackPressed()
+        shadowOf(Looper.getMainLooper()).runToEndOfTasks()
+
+        verify(mockEventProcessor).onCheckoutCanceled()
+        assertThat(dialog.isShowing).isFalse()
+        assertThat(shadowOf(webView).goBackInvocations).isEqualTo(0)
+    }
+
+    private fun CheckoutDialog.currentWebView(): BaseWebView =
+        findViewById<RelativeLayout>(R.id.checkoutSdkContainer)
+            .children.first { it is BaseWebView } as BaseWebView
+
     private fun backgroundColor(view: View): Int {
         return (view.background as ColorDrawable).color
     }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/UriExtensionsTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/UriExtensionsTest.kt
@@ -54,8 +54,8 @@ class UriExtensionsTest {
     }
 
     @Test
-    fun `isConfirmationPage matches regardless of segment position`() {
-        assertThat("https://shop.com/checkouts/c/abc/thank_you".toUri().isConfirmationPage()).isTrue()
+    fun `isConfirmationPage returns true for thank-you non-last segment`() {
+        assertThat("https://shop.com/cn-12345/foo/thank-you/bar".toUri().isConfirmationPage()).isTrue()
     }
 
     @Test

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/UriExtensionsTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/UriExtensionsTest.kt
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright 2023-present, Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.shopify.checkoutsheetkit
+
+import android.net.Uri
+import androidx.core.net.toUri
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UriExtensionsTest {
+
+    @Test
+    fun `isConfirmationPage returns true for thank-you path segment`() {
+        assertThat("https://shop.com/cn-12345/thank-you".toUri().isConfirmationPage()).isTrue()
+    }
+
+    @Test
+    fun `isConfirmationPage returns true for thank_you path segment`() {
+        assertThat("https://shop.com/cn-12345/thank_you".toUri().isConfirmationPage()).isTrue()
+    }
+
+    @Test
+    fun `isConfirmationPage is case insensitive`() {
+        assertThat("https://shop.com/cn-12345/THANK-YOU".toUri().isConfirmationPage()).isTrue()
+        assertThat("https://shop.com/cn-12345/Thank_You".toUri().isConfirmationPage()).isTrue()
+    }
+
+    @Test
+    fun `isConfirmationPage matches when followed by a query string`() {
+        assertThat("https://shop.com/cn-12345/thank-you?order_id=42".toUri().isConfirmationPage()).isTrue()
+    }
+
+    @Test
+    fun `isConfirmationPage matches regardless of segment position`() {
+        assertThat("https://shop.com/checkouts/c/abc/thank_you".toUri().isConfirmationPage()).isTrue()
+    }
+
+    @Test
+    fun `isConfirmationPage returns false for non-confirmation paths`() {
+        assertThat("https://shop.com/cn-12345/checkout".toUri().isConfirmationPage()).isFalse()
+        assertThat("https://shop.com/products/widget".toUri().isConfirmationPage()).isFalse()
+        assertThat("https://shop.com/".toUri().isConfirmationPage()).isFalse()
+    }
+
+    @Test
+    fun `isConfirmationPage returns false when thank-you is only a substring`() {
+        assertThat("https://shop.com/thank-you-page".toUri().isConfirmationPage()).isFalse()
+        assertThat("https://shop.com/pre-thank-you".toUri().isConfirmationPage()).isFalse()
+        assertThat("https://shop.com/prethankyou".toUri().isConfirmationPage()).isFalse()
+    }
+
+    @Test
+    fun `isConfirmationPage returns false when thank-you appears only in the query string`() {
+        assertThat("https://shop.com/checkout?next=thank-you".toUri().isConfirmationPage()).isFalse()
+    }
+
+    @Test
+    fun `isConfirmationPage returns false for null uri`() {
+        val uri: Uri? = null
+        assertThat(uri.isConfirmationPage()).isFalse()
+    }
+}

--- a/samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml
+++ b/samples/MobileBuyIntegration/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
         android:name=".MobileBuyIntegration"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -48,7 +49,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Androidsample"
-        tools:targetApi="31">
+        tools:targetApi="33">
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|keyboardHidden"


### PR DESCRIPTION
### What changes are you making?

Prevent swiping back from TYP to checkout. After checkout is complete, navigation back actually leads to a storefront redirect, and we don't want end users landing on the storefront in our checkout web view.

Instead we should close the webview on swipe back when on the TYP.

### Changes

- Switched `CheckoutDialog` to `ComponentDialog` and centralized all back handling in an `OnBackPressedCallback` on `onBackPressedDispatcher`. This covers both legacy `KEYCODE_BACK` and the predictive-back dispatcher.
- Callback delegates to a new `BaseWebView.handleBackPressed()` helper, which goes back in WebView history only when `canGoBack()` && `!isOnConfirmationPage();` otherwise the dialog dismisses.
- Extracted `Uri.isConfirmationPage()` into `UriExtensions` (shared with FallbackWebView's existing TYP detection).
- Removed the old `BaseWebView.onKeyDown` override — redundant now that the dispatcher handles both paths.
- Added UriExtensionsTest.

### How to test

In sample, complete a checkout, redirect to TYP, swipe back.
Repeat on main

### Before you merge

> [!IMPORTANT]
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.