### PR TITLE
bump-mat3-and-replace-icon-usage

### DIFF
--- a/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/products/collection/ProductCollections.kt
+++ b/samples/MobileBuyIntegration/app/src/main/java/com/shopify/checkout_sdk_mobile_buy_integration_sample/products/collection/ProductCollections.kt
@@ -29,14 +29,13 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.shopify.checkout_sdk_mobile_buy_integration_sample.R
@@ -109,7 +108,7 @@ fun ProductCollection(
                 modifier = Modifier.padding(top = 10.dp)
             )
             Icon(
-                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                painter = painterResource(id = R.drawable.arrow_forward),
                 contentDescription = stringResource(id = R.string.collection_cta_content_description),
                 modifier = Modifier.padding(start = 5.dp, top = 10.dp)
             )

--- a/samples/MobileBuyIntegration/app/src/main/res/drawable/arrow_forward.xml
+++ b/samples/MobileBuyIntegration/app/src/main/res/drawable/arrow_forward.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M647,520L160,520v-80h487L423,216l57,-56 320,320 -320,320 -57,-56 224,-224Z"
+      android:fillColor="#1f1f1f"/>
+</vector>

--- a/samples/MobileBuyIntegration/build.gradle
+++ b/samples/MobileBuyIntegration/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         koin_android_compose_version = '4.2.1'
         kotlin_serialization_version = '1.8.1'
         lifecycle_version = '2.10.0'
-        material3_version = '1.3.2'
+        material3_version = '1.4.0'
         nav_version = '2.9.7'
         paging_version = '3.4.2'
         room_version = '2.8.4'


### PR DESCRIPTION
### What changes are you making?

Bumping and following the advice here

```
https://developer.android.com/jetpack/androidx/releases/compose-material3#compose_material3_version_14_2
```

> **Library change announcements**
>
> The **`androidx.compose.material.icons`** library is **no longer recommended** for displaying Material Icons in Compose, as Material Symbols are the new way forward. We have stopped publishing updates to this library and it has been removed from the latest Material 3 library release, you can still manually reference it if you cannot migrate yet.
>
> Instead, we recommend downloading a Vector Drawable XML file from the Android tab of https://fonts.google.com/icons to get access to the latest styled icons: Material Symbols.
>
> Why are we not recommending the library anymore? The icons library ("Material Icons") have been superseded by the newer look of Material Symbols and we've seen that the library can increase the build time of your apps significantly as it includes all the various icons that may not be needed.
>
> For more information: https://developer.android.com/develop/ui/compose/graphics/images/material

<!-- Please describe why you are making these changes -->

### How to test

<!-- Please outline the steps to test your changes -->

---

### Before you merge

> [!IMPORTANT]
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.