### PR TITLE
Add Dependabot cooldown to delay version bump PRs by 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   
   # Main library
   - package-ecosystem: gradle
@@ -11,6 +13,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
     ignore:
       # Keep Kotlin on 1.9.x for compatibility
       - dependency-name: "org.jetbrains.kotlin.*"
@@ -31,6 +35,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
       apollo:
         patterns:


### PR DESCRIPTION
Adds a 7-day cooldown to all Dependabot update blocks via the `cooldown.default-days` setting. New releases will only be proposed as update PRs once they have been published for at least 7 days.

This gives time for problematic releases (including supply-chain compromises) to be identified and yanked before we pick them up.

Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

Requested by Daniel Kift <daniel.kift@shopify.com>

### What changes are you making?

<!-- Please describe why you are making these changes -->

### How to test

<!-- Please outline the steps to test your changes -->

---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
