### PR TITLE
set gradle version error to informational

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -56,6 +56,7 @@ android {
         checkDependencies = true
         warningsAsErrors = true
         warning 'LintBaseline'
+        informational 'AndroidGradlePluginVersion'
     }
 
     buildTypes {


### PR DESCRIPTION
### What changes are you making?

CI lint was failing with `AndroidGradlePluginVersion` after Gradle 9.5.0 shipped, because warningsAsErrors = true promotes any "newer version available" nudge into a build-breaking error the moment upstream cuts a release.

We deliberately don't chase brand-new releases — letting versions settle for a few days is part of how we limit exposure to supply-chain issues — so this check failing the build the same day a release lands is too aggressive for our update cadence.

### Resolution

Demoted AndroidGradlePluginVersion to informational in lib/build.gradle's lint {} block. The check still runs and surfaces in lint reports (so we don't lose visibility into available updates), but no longer fails the build.

Other lint checks remain promoted to errors via warningsAsErrors = true.

### Test plan

  - ./gradlew :lib:lintRelease passes locally
  - CI lint job is green

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
