### PR TITLE
Handle delayed checkout bridge availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ your project:
 ### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.6.0"
+implementation "com.shopify:checkout-sheet-kit:3.6.1"
 ```
 
 ### Maven
@@ -65,7 +65,7 @@ implementation "com.shopify:checkout-sheet-kit:3.6.0"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.6.0</version>
+   <version>3.6.1</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,7 +16,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.6.0")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.6.1")
 
 ext {
     app_compat_version = '1.7.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutBridge.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutBridge.kt
@@ -173,13 +173,51 @@ internal class CheckoutBridge(
         const val SCHEMA_VERSION_NUMBER: String = "8.1"
 
         private fun dispatchMessageTemplate(body: String) = """|
-        |if (window.MobileCheckoutSdk && window.MobileCheckoutSdk.dispatchMessage) {
-        |    window.MobileCheckoutSdk.dispatchMessage($body);
-        |} else {
-        |    window.addEventListener('mobileCheckoutBridgeReady', function () {
+        |(function () {
+        |    var maxAttempts = 50;
+        |    var intervalMs = 100;
+        |    var attempts = 0;
+        |    var intervalId;
+        |    var didDispatch = false;
+        |
+        |    function bridgeReady() {
+        |        return window.MobileCheckoutSdk && typeof window.MobileCheckoutSdk.dispatchMessage === 'function';
+        |    }
+        |
+        |    function cleanup() {
+        |        window.removeEventListener('mobileCheckoutBridgeReady', onBridgeReady);
+        |        if (intervalId) {
+        |            window.clearInterval(intervalId);
+        |        }
+        |    }
+        |
+        |    function dispatchMessage() {
+        |        if (didDispatch || !bridgeReady()) {
+        |            return false;
+        |        }
+        |
+        |        didDispatch = true;
+        |        cleanup();
         |        window.MobileCheckoutSdk.dispatchMessage($body);
-        |    }, {passive: true, once: true});
-        |}
+        |        return true;
+        |    }
+        |
+        |    function onBridgeReady() {
+        |        dispatchMessage();
+        |    }
+        |
+        |    if (dispatchMessage()) {
+        |        return;
+        |    }
+        |
+        |    window.addEventListener('mobileCheckoutBridgeReady', onBridgeReady, {passive: true});
+        |    intervalId = window.setInterval(function () {
+        |        attempts += 1;
+        |        if (dispatchMessage() || attempts >= maxAttempts) {
+        |            cleanup();
+        |        }
+        |    }, intervalMs);
+        |})();
         |
         """.trimMargin()
     }

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutBridgeTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutBridgeTest.kt
@@ -99,18 +99,37 @@ class CheckoutBridgeTest {
         checkoutBridge.sendMessage(webView, CheckoutBridge.SDKOperation.Presented)
 
         verify(webView).evaluateJavascript(
-            """|
-        |if (window.MobileCheckoutSdk && window.MobileCheckoutSdk.dispatchMessage) {
-        |    window.MobileCheckoutSdk.dispatchMessage('presented');
-        |} else {
-        |    window.addEventListener('mobileCheckoutBridgeReady', function () {
-        |        window.MobileCheckoutSdk.dispatchMessage('presented');
-        |    }, {passive: true, once: true});
-        |}
-        |
-            """.trimMargin(),
+            expectedDispatchJavascript("'presented'"),
             null
         )
+    }
+
+    @Test
+    fun `sendMessage waits for delayed bridge availability`() {
+        val script = scriptFor(CheckoutBridge.SDKOperation.Presented)
+        val listenerRegistration = "window.addEventListener('mobileCheckoutBridgeReady', onBridgeReady, {passive: true});"
+
+        assertThat(script).contains(listenerRegistration)
+        assertThat(script).contains("intervalId = window.setInterval(function () {")
+        assertThat(script).contains("typeof window.MobileCheckoutSdk.dispatchMessage === 'function';")
+    }
+
+    @Test
+    fun `sendMessage prevents duplicate dispatches`() {
+        val script = scriptFor(CheckoutBridge.SDKOperation.Presented)
+
+        assertThat(script).contains("if (didDispatch || !bridgeReady()) {")
+        assertThat(script).contains("didDispatch = true;")
+        assertThat(script).contains("window.removeEventListener('mobileCheckoutBridgeReady', onBridgeReady);")
+    }
+
+    @Test
+    fun `sendMessage stops polling after timeout`() {
+        val script = scriptFor(CheckoutBridge.SDKOperation.Presented)
+
+        assertThat(script).contains("var maxAttempts = 50;")
+        assertThat(script).contains("attempts >= maxAttempts")
+        assertThat(script).contains("window.clearInterval(intervalId);")
     }
 
     @Test
@@ -141,16 +160,7 @@ class CheckoutBridgeTest {
             tags = mapOf("tag1" to "value1", "tag2" to "value2")
         )
         val expectedPayload = """{"detail":{"name":"Test","value":123,"type":"histogram","tags":{"tag1":"value1","tag2":"value2"}}}"""
-        val expectedJavascript = """|
-        |if (window.MobileCheckoutSdk && window.MobileCheckoutSdk.dispatchMessage) {
-        |    window.MobileCheckoutSdk.dispatchMessage('instrumentation', $expectedPayload);
-        |} else {
-        |    window.addEventListener('mobileCheckoutBridgeReady', function () {
-        |        window.MobileCheckoutSdk.dispatchMessage('instrumentation', $expectedPayload);
-        |    }, {passive: true, once: true});
-        |}
-        |
-        """.trimMargin()
+        val expectedJavascript = expectedDispatchJavascript("'instrumentation', $expectedPayload")
 
         checkoutBridge.sendMessage(webView, CheckoutBridge.SDKOperation.Instrumentation(payload))
 
@@ -361,4 +371,64 @@ class CheckoutBridgeTest {
         assertThat(error.isRecoverable).isTrue()
         assertThat(error.errorCode).isEqualTo(CheckoutSheetKitException.ERROR_RECEIVING_MESSAGE_FROM_CHECKOUT)
     }
+
+    private fun scriptFor(operation: CheckoutBridge.SDKOperation): String {
+        val webView = mock<WebView>()
+
+        checkoutBridge.sendMessage(webView, operation)
+
+        val scriptCaptor = argumentCaptor<String>()
+        verify(webView).evaluateJavascript(scriptCaptor.capture(), eq(null))
+
+        return scriptCaptor.firstValue
+    }
+
+    private fun expectedDispatchJavascript(body: String) = """|
+        |(function () {
+        |    var maxAttempts = 50;
+        |    var intervalMs = 100;
+        |    var attempts = 0;
+        |    var intervalId;
+        |    var didDispatch = false;
+        |
+        |    function bridgeReady() {
+        |        return window.MobileCheckoutSdk && typeof window.MobileCheckoutSdk.dispatchMessage === 'function';
+        |    }
+        |
+        |    function cleanup() {
+        |        window.removeEventListener('mobileCheckoutBridgeReady', onBridgeReady);
+        |        if (intervalId) {
+        |            window.clearInterval(intervalId);
+        |        }
+        |    }
+        |
+        |    function dispatchMessage() {
+        |        if (didDispatch || !bridgeReady()) {
+        |            return false;
+        |        }
+        |
+        |        didDispatch = true;
+        |        cleanup();
+        |        window.MobileCheckoutSdk.dispatchMessage($body);
+        |        return true;
+        |    }
+        |
+        |    function onBridgeReady() {
+        |        dispatchMessage();
+        |    }
+        |
+        |    if (dispatchMessage()) {
+        |        return;
+        |    }
+        |
+        |    window.addEventListener('mobileCheckoutBridgeReady', onBridgeReady, {passive: true});
+        |    intervalId = window.setInterval(function () {
+        |        attempts += 1;
+        |        if (dispatchMessage() || attempts >= maxAttempts) {
+        |            cleanup();
+        |        }
+        |    }, intervalMs);
+        |})();
+        |
+    """.trimMargin()
 }


### PR DESCRIPTION
### What changes are you making?

Addresses Shopify/checkout-sheet-kit-react-native#488.

React Native apps can present checkout directly without calling `preload()`. In that path, native may send the `presented` message before `window.MobileCheckoutSdk.dispatchMessage` is available, which makes checkout event delivery unreliable for the session.

This updates the native-to-web dispatch template so SDK messages:

- dispatch immediately when `window.MobileCheckoutSdk.dispatchMessage` is already available
- wait for the bridge-ready event when checkout is still initializing
- also poll for bridge availability for a bounded window, so dispatch does not depend on catching one transient event
- dispatch at most once and clean up listeners/timers after success or timeout

This keeps the existing bridge contract intact: native waits for `window.MobileCheckoutSdk.dispatchMessage` to become available before dispatching.

Related context: Shopify/checkout-sheet-kit-react-native#490.

### How to test

- `./gradlew :lib:testDebugUnitTest --tests com.shopify.checkoutsheetkit.CheckoutBridgeTest`
- `./gradlew :lib:test :lib:apiCheck :lib:detekt :lib:lintRelease :lib:assembleRelease`

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [x] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
