### PR TITLE
Handle checkout-owned HTTP errors across origin changes

### DIFF
--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -42,6 +42,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.core.net.toUri
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
 import com.shopify.checkoutsheetkit.ShopifyCheckoutSheetKit.log
@@ -51,6 +52,8 @@ import java.net.HttpURLConnection.HTTP_GONE
 internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet? = null) :
     WebView(context, attributeSet) {
 
+    private val checkoutOrigins = mutableSetOf<UriOrigin>()
+
     init {
         configureWebView()
     }
@@ -59,6 +62,29 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
     abstract val recoverErrors: Boolean
     abstract val variant: String
     abstract val cspSchema: String
+
+    internal fun setCheckoutOrigin(url: String) {
+        checkoutOrigins.clear()
+        url.toUri().toOrigin()?.let(checkoutOrigins::add)
+    }
+
+    internal fun shouldHandleMainFrameError(request: WebResourceRequest?): Boolean {
+        val isMainFrame = request?.isForMainFrame == true
+        val requestUrl = request?.url
+        val requestOrigin = requestUrl?.toOrigin()
+
+        return isMainFrame && (
+            checkoutOrigins.isEmpty() ||
+                requestOrigin == null ||
+                checkoutOrigins.contains(requestOrigin) ||
+                shouldAllowCheckoutOriginTransition(requestOrigin, requestUrl)
+            )
+    }
+
+    private fun shouldAllowCheckoutOriginTransition(requestOrigin: UriOrigin, requestUrl: Uri?): Boolean {
+        val hasShopAppOrigin = requestOrigin.host == SHOP_APP_HOST || checkoutOrigins.any { it.host == SHOP_APP_HOST }
+        return hasShopAppOrigin && requestUrl?.hasCheckoutPath() == true
+    }
 
     private fun configureWebView() {
         visibility = VISIBLE
@@ -204,34 +230,34 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
             errorCode: Int,
             errorDescription: String,
         ) {
-            if (request?.isForMainFrame == true) {
-                log.d(
-                    LOG_TAG,
-                    "Handling error for main frame. URL: ${request.url}, errorCode: $errorCode, errorDescription: $errorDescription"
-                )
-                val processor = getEventProcessor()
-                when {
-                    errorCode == HTTP_GONE -> {
-                        log.d(LOG_TAG, "Failing with cart expired. Recoverable: false")
-                        processor.onCheckoutViewFailedWithError(
-                            CheckoutExpiredException(
-                                isRecoverable = false,
-                                errorCode = CheckoutExpiredException.CART_EXPIRED
-                            ),
-                        )
-                    }
+            if (!shouldHandleMainFrameError(request)) return
 
-                    else -> {
-                        val recoverable = isRecoverable(errorCode)
-                        log.d(LOG_TAG, "Failing with other error. Code: $errorCode. Recoverable $recoverable")
-                        processor.onCheckoutViewFailedWithError(
-                            HttpException(
-                                errorDescription = errorDescription,
-                                statusCode = errorCode,
-                                isRecoverable = recoverable
-                            )
+            log.d(
+                LOG_TAG,
+                "Handling error for main frame. URL: ${request?.url}, errorCode: $errorCode, errorDescription: $errorDescription"
+            )
+            val processor = getEventProcessor()
+            when {
+                errorCode == HTTP_GONE -> {
+                    log.d(LOG_TAG, "Failing with cart expired. Recoverable: false")
+                    processor.onCheckoutViewFailedWithError(
+                        CheckoutExpiredException(
+                            isRecoverable = false,
+                            errorCode = CheckoutExpiredException.CART_EXPIRED
                         )
-                    }
+                    )
+                }
+
+                else -> {
+                    val recoverable = isRecoverable(errorCode)
+                    log.d(LOG_TAG, "Failing with other error. Code: $errorCode. Recoverable $recoverable")
+                    processor.onCheckoutViewFailedWithError(
+                        HttpException(
+                            errorDescription = errorDescription,
+                            statusCode = errorCode,
+                            isRecoverable = recoverable
+                        )
+                    )
                 }
             }
         }
@@ -243,6 +269,52 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
         private val CLIENT_ERROR = 400..499
     }
 }
+
+private data class UriOrigin(
+    val scheme: String,
+    val host: String,
+    val port: Int?,
+)
+
+private fun Uri.toOrigin(): UriOrigin? {
+    val scheme = scheme?.lowercase()
+    val host = host?.lowercase()
+
+    return if (scheme == null || host == null) {
+        null
+    } else {
+        val port = if (port == -1) defaultPortForScheme(scheme) else port
+        UriOrigin(scheme, host, port)
+    }
+}
+
+private fun defaultPortForScheme(scheme: String): Int? {
+    return when (scheme) {
+        "http" -> HTTP_DEFAULT_PORT
+        "https" -> HTTPS_DEFAULT_PORT
+        else -> null
+    }
+}
+
+private fun Uri.hasCheckoutPath(): Boolean {
+    val segments = pathSegments
+    return (
+        segments.size >= MIN_CHECKOUTS_PATH_SEGMENTS &&
+            segments[0] == CHECKOUTS_PATH_SEGMENT
+        ) || (
+        segments.size >= MIN_CHECKOUT_PATH_SEGMENTS &&
+            segments[0] == CHECKOUT_PATH_SEGMENT &&
+            segments[1].all(Char::isDigit)
+        )
+}
+
+private const val HTTP_DEFAULT_PORT = 80
+private const val HTTPS_DEFAULT_PORT = 443
+private const val SHOP_APP_HOST = "shop.app"
+private const val CHECKOUTS_PATH_SEGMENT = "checkouts"
+private const val CHECKOUT_PATH_SEGMENT = "checkout"
+private const val MIN_CHECKOUTS_PATH_SEGMENTS = 3
+private const val MIN_CHECKOUT_PATH_SEGMENTS = 4
 
 /**
  * Removes the WebView from its parent if a parent exists

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -105,6 +105,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
         log.d(LOG_TAG, "Loading checkout with url $url. IsPreload: $isPreload.")
         initLoadTime = System.currentTimeMillis()
         this.isPreload = isPreload
+        setCheckoutOrigin(url)
         Handler(Looper.getMainLooper()).post {
             val headers = if (isPreload) mutableMapOf("Shopify-Purpose" to "prefetch") else mutableMapOf()
             loadUrl(url, headers)

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
@@ -178,6 +178,98 @@ class CheckoutWebViewClientTest {
     }
 
     @Test
+    fun `should call event processor on http error for same origin checkout url`() {
+        val mockRequest = mockWebRequest(Uri.parse("https://checkout-sdk.myshopify.com/cart/c/123"), true)
+        val mockResponse = mockWebResourceResponse(
+            status = HttpURLConnection.HTTP_NOT_FOUND,
+            description = "Not Found",
+        )
+
+        triggerOnReceivedHttpError(
+            mockRequest,
+            mockResponse,
+            checkoutUrl = "https://checkout-sdk.myshopify.com/checkouts/cn/123",
+        )
+
+        val captor = argumentCaptor<CheckoutException>()
+        verify(checkoutWebViewEventProcessor).onCheckoutViewFailedWithError(captor.capture())
+        assertThat(captor.firstValue)
+            .isInstanceOf(HttpException::class.java)
+            .hasErrorCode(CheckoutUnavailableException.HTTP_ERROR)
+            .isNotRecoverable()
+            .hasDescription("Not Found")
+            .hasStatusCode(404)
+    }
+
+    @Test
+    fun `should call event processor on http error for checkout-shaped shop app transition`() {
+        val mockRequest = mockWebRequest(Uri.parse("https://checkout-sdk.myshopify.com/checkouts/cn/123"), true)
+        val mockResponse = mockWebResourceResponse(
+            status = HttpURLConnection.HTTP_NOT_FOUND,
+            description = "Not Found",
+        )
+
+        triggerOnReceivedHttpError(
+            mockRequest,
+            mockResponse,
+            checkoutUrl = "https://shop.app/checkout/123/cn/123",
+        )
+
+        val captor = argumentCaptor<CheckoutException>()
+        verify(checkoutWebViewEventProcessor).onCheckoutViewFailedWithError(captor.capture())
+        assertThat(captor.firstValue)
+            .isInstanceOf(HttpException::class.java)
+            .hasStatusCode(404)
+    }
+
+    @Test
+    fun `should not call event processor on http error for third party main frame`() {
+        val mockRequest = mockWebRequest(Uri.parse("https://process.paypo.pl/smartplan/123"), true)
+        val mockResponse = mockWebResourceResponse(
+            status = HttpURLConnection.HTTP_NOT_FOUND,
+            description = "Not Found",
+        )
+
+        triggerOnReceivedHttpError(
+            mockRequest,
+            mockResponse,
+            checkoutUrl = "https://checkout-sdk.myshopify.com/checkouts/cn/123",
+        )
+
+        verify(checkoutWebViewEventProcessor, never()).onCheckoutViewFailedWithError(any())
+    }
+
+    @Test
+    fun `should not call event processor on http error for third party main frame after shop app checkout`() {
+        val mockRequest = mockWebRequest(Uri.parse("https://process.paypo.pl/smartplan/123"), true)
+        val mockResponse = mockWebResourceResponse(
+            status = HttpURLConnection.HTTP_NOT_FOUND,
+            description = "Not Found",
+        )
+
+        triggerOnReceivedHttpError(
+            mockRequest,
+            mockResponse,
+            checkoutUrl = "https://shop.app/checkout/123/cn/123",
+        )
+
+        verify(checkoutWebViewEventProcessor, never()).onCheckoutViewFailedWithError(any())
+    }
+
+    @Test
+    fun `should not call event processor on http error for subresource`() {
+        val mockRequest = mockWebRequest(Uri.parse("https://checkout-sdk.myshopify.com/assets/script.js"), false)
+        val mockResponse = mockWebResourceResponse(
+            status = HttpURLConnection.HTTP_NOT_FOUND,
+            description = "Not Found",
+        )
+
+        triggerOnReceivedHttpError(mockRequest, mockResponse)
+
+        verify(checkoutWebViewEventProcessor, never()).onCheckoutViewFailedWithError(any())
+    }
+
+    @Test
     fun `should call event processor calls onCheckoutViewFailedWithError on http error for main frame - 500`() {
         val mockRequest = mockWebRequest(Uri.parse("https://checkout-sdk.myshopify.com"), true)
         val mockResponse = mockWebResourceResponse(
@@ -356,8 +448,13 @@ class CheckoutWebViewClientTest {
             .hasErrorCode(CheckoutSheetKitException.RENDER_PROCESS_GONE)
     }
 
-    private fun triggerOnReceivedHttpError(mockRequest: WebResourceRequest, checkoutExpiredResponse: WebResourceResponse) {
+    private fun triggerOnReceivedHttpError(
+        mockRequest: WebResourceRequest,
+        checkoutExpiredResponse: WebResourceResponse,
+        checkoutUrl: String = mockRequest.url.toString(),
+    ) {
         val view = viewWithProcessor(activity)
+        view.setCheckoutOrigin(checkoutUrl)
         CheckoutWebView.cacheEntry = view.toCacheEntry(mockRequest.url.toString())
         val webViewClient = view.CheckoutWebViewClient()
 


### PR DESCRIPTION
### What changes are you making?

Handle WebView HTTP-status failure handling when checkout moves between `shop.app` and merchant checkout URLs.

This keeps checkout HTTP failures such as 404, 410, and 5xx responses working across that checkout-owned transition, while allowing offsite payment pages to render their own main-frame responses.

Regression coverage was added for checkout-shaped `shop.app` transitions and offsite main-frame HTTP responses.

Related to Shopify/checkout-sheet-kit-react-native#493.

### How to test

- `./gradlew :lib:testDebugUnitTest --tests com.shopify.checkoutsheetkit.CheckoutWebViewClientTest`
- `./gradlew :lib:lintRelease detekt`

---

### Before you merge

> [!IMPORTANT]
>
> - [x] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).
>
> README update not needed; this does not change public API or documented integration behavior.

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
