### PR TITLE
release 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ your project:
 ### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.6.0"
+implementation "com.shopify:checkout-sheet-kit:3.6.1"
 ```
 
 ### Maven
@@ -65,7 +65,7 @@ implementation "com.shopify:checkout-sheet-kit:3.6.0"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.6.0</version>
+   <version>3.6.1</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,7 +16,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.6.0")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.6.1")
 
 ext {
     app_compat_version = '1.7.1'


### PR DESCRIPTION
### What changes are you making?

Bumps the library version from `3.6.0` to `3.6.1`. This updates the version in both the `build.gradle` file and the README installation instructions for Gradle and Maven.

### How to test

1. Update the dependency in a project using either Gradle or Maven to version `3.6.1`.
2. Verify the library builds and runs correctly.

---

### Before you merge

> [!IMPORTANT]
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [x] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [x] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.