### PR TITLE
fix: publish Kotlin 1.9.23 stdlib for 3.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ your project:
 ### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.6.0"
+implementation "com.shopify:checkout-sheet-kit:3.6.1"
 ```
 
 ### Maven
@@ -65,7 +65,7 @@ implementation "com.shopify:checkout-sheet-kit:3.6.0"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.6.0</version>
+   <version>3.6.1</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,7 +16,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.6.0")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.6.1")
 
 ext {
     app_compat_version = '1.7.1'
@@ -120,6 +120,11 @@ dependencies {
 
     androidTestImplementation "androidx.test:core-ktx:$androidx_test_version"
     androidTestImplementation "androidx.test.ext:junit-ktx:$androidx_junit_ext_version"
+
+    // Declare the consumer stdlib floor explicitly. Otherwise AGP 9's built-in
+    // Kotlin support publishes its bundled 2.2.10 stdlib as an API dependency,
+    // despite this library being compiled with KGP 1.9.23 and a 1.9 API floor.
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.9.23"
 
     //Implementation
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlin_serialization_version"


### PR DESCRIPTION
### What changes are you making?

Bumps the library version from `3.6.0` to `3.6.1` and explicitly declares `org.jetbrains.kotlin:kotlin-stdlib:1.9.23` as an implementation dependency. This prevents AGP 9's built-in Kotlin support from publishing its bundled 2.2.10 stdlib as an API dependency, which would be inconsistent with the library being compiled against KGP 1.9.23 with a 1.9 API floor.

### How to test

1. Build the library and verify the published POM declares `kotlin-stdlib:1.9.23` rather than a 2.x version.
2. Integrate the library into a consumer project and confirm no unexpected stdlib version conflicts are introduced.

---

### Before you merge

> [!IMPORTANT]
> - [ ] I've added tests to support my implementation
> - [x] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [x] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [x] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [x] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.