### PR TITLE
Allow Cloudflare managed challenges to render

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ your project:
 ### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.6.1"
+implementation "com.shopify:checkout-sheet-kit:3.6.2"
 ```
 
 ### Maven
@@ -65,7 +65,7 @@ implementation "com.shopify:checkout-sheet-kit:3.6.1"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.6.1</version>
+   <version>3.6.2</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,7 +16,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.6.1")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.6.2")
 
 ext {
     app_compat_version = '1.7.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -181,7 +181,9 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
             errorResponse: WebResourceResponse?
         ) {
             super.onReceivedHttpError(view, request, errorResponse)
-            if (errorResponse != null) {
+            if (errorResponse?.isCloudflareManagedChallenge() == true) {
+                log.d(LOG_TAG, "Allowing Cloudflare managed challenge response to render.")
+            } else if (errorResponse != null) {
                 handleError(
                     request,
                     errorResponse.statusCode,
@@ -239,8 +241,16 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
 
     companion object {
         private const val LOG_TAG = "BaseWebView"
+        private const val CLOUDFLARE_MITIGATED_HEADER = "cf-mitigated"
+        private const val CLOUDFLARE_CHALLENGE_VALUE = "challenge"
         private const val TOO_MANY_REQUESTS = 429
         private val CLIENT_ERROR = 400..499
+
+        private fun WebResourceResponse.isCloudflareManagedChallenge(): Boolean =
+            responseHeaders?.entries?.any { (name, value) ->
+                name.equals(CLOUDFLARE_MITIGATED_HEADER, ignoreCase = true) &&
+                    value.trim().equals(CLOUDFLARE_CHALLENGE_VALUE, ignoreCase = true)
+            } == true
     }
 }
 

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -182,7 +182,7 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
         ) {
             super.onReceivedHttpError(view, request, errorResponse)
             if (errorResponse?.isCloudflareManagedChallenge() == true) {
-                log.d(LOG_TAG, "Allowing Cloudflare managed challenge response to render.")
+                handleCloudflareManagedChallenge(request)
             } else if (errorResponse != null) {
                 handleError(
                     request,
@@ -190,6 +190,10 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
                     errorResponse.reasonPhrase.ifBlank { "HTTP ${errorResponse.statusCode} Error" },
                 )
             }
+        }
+
+        internal open fun handleCloudflareManagedChallenge(request: WebResourceRequest?) {
+            log.d(LOG_TAG, "Allowing Cloudflare managed challenge response to render.")
         }
 
         internal open fun isRecoverable(statusCode: Int): Boolean {

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -44,6 +44,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
     override val variant = "standard"
     override val cspSchema = CheckoutBridge.SCHEMA_VERSION_NUMBER
     var isPreload = false
+    private var isCheckoutVisible = false
 
     private val checkoutBridge = CheckoutBridge(CheckoutWebViewEventProcessor(NoopEventProcessor()))
     private var loadComplete = false
@@ -91,11 +92,13 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        isCheckoutVisible = true
         log.d(LOG_TAG, "Attached to window. Adding JavaScript interface with name $JAVASCRIPT_INTERFACE_NAME.")
         addJavascriptInterface(checkoutBridge, JAVASCRIPT_INTERFACE_NAME)
     }
 
     override fun onDetachedFromWindow() {
+        isCheckoutVisible = false
         super.onDetachedFromWindow()
         log.d(LOG_TAG, "Detached from window. Removing JavaScript interface with name $JAVASCRIPT_INTERFACE_NAME.")
         removeJavascriptInterface(JAVASCRIPT_INTERFACE_NAME)
@@ -114,7 +117,7 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
     inner class CheckoutWebViewClient : BaseWebView.BaseWebViewClient() {
 
         override fun handleCloudflareManagedChallenge(request: WebResourceRequest?) {
-            if (request?.isForMainFrame == true && isPreload && !presented) {
+            if (request?.isForMainFrame == true && isPreload && !isCheckoutVisible) {
                 log.d(LOG_TAG, "Discarding preloaded Cloudflare managed challenge response.")
                 stopLoading()
                 markCacheEntryStale()

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/CheckoutWebView.kt
@@ -113,6 +113,18 @@ internal class CheckoutWebView(context: Context, attributeSet: AttributeSet? = n
 
     inner class CheckoutWebViewClient : BaseWebView.BaseWebViewClient() {
 
+        override fun handleCloudflareManagedChallenge(request: WebResourceRequest?) {
+            if (request?.isForMainFrame == true && isPreload && !presented) {
+                log.d(LOG_TAG, "Discarding preloaded Cloudflare managed challenge response.")
+                stopLoading()
+                markCacheEntryStale()
+                clearCache()
+                return
+            }
+
+            super.handleCloudflareManagedChallenge(request)
+        }
+
         override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
             super.onPageStarted(view, url, favicon)
             log.d(LOG_TAG, "onPageStarted called $url.")

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
@@ -178,6 +178,23 @@ class CheckoutWebViewClientTest {
     }
 
     @Test
+    fun `should allow a Cloudflare managed challenge response to render`() {
+        val mockRequest = mockWebRequest(
+            Uri.parse("https://checkout-sdk.myshopify.com"),
+            forMainFrame = true,
+        )
+        val mockResponse = mockWebResourceResponse(
+            status = HttpURLConnection.HTTP_FORBIDDEN,
+            description = "Forbidden",
+            headers = mutableMapOf("Cf-Mitigated" to " Challenge "),
+        )
+
+        triggerOnReceivedHttpError(mockRequest, mockResponse)
+
+        verify(checkoutWebViewEventProcessor, never()).onCheckoutViewFailedWithError(any())
+    }
+
+    @Test
     fun `should call event processor calls onCheckoutViewFailedWithError on http error for main frame - 500`() {
         val mockRequest = mockWebRequest(Uri.parse("https://checkout-sdk.myshopify.com"), true)
         val mockResponse = mockWebResourceResponse(

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
@@ -178,7 +178,7 @@ class CheckoutWebViewClientTest {
     }
 
     @Test
-    fun `should allow a Cloudflare managed challenge response to render`() {
+    fun `should allow a presented Cloudflare managed challenge response to render`() {
         val mockRequest = mockWebRequest(
             Uri.parse("https://checkout-sdk.myshopify.com"),
             forMainFrame = true,
@@ -189,9 +189,39 @@ class CheckoutWebViewClientTest {
             headers = mutableMapOf("Cf-Mitigated" to " Challenge "),
         )
 
-        triggerOnReceivedHttpError(mockRequest, mockResponse)
+        val view = viewWithProcessor(activity)
+        view.isPreload = true
+        view.notifyPresented()
+        CheckoutWebView.cacheEntry = view.toCacheEntry(mockRequest.url.toString())
+
+        view.CheckoutWebViewClient().onReceivedHttpError(view, mockRequest, mockResponse)
+        ShadowLooper.shadowMainLooper().runToEndOfTasks()
 
         verify(checkoutWebViewEventProcessor, never()).onCheckoutViewFailedWithError(any())
+        assertThat(CheckoutWebView.cacheEntry).isNotNull()
+    }
+
+    @Test
+    fun `should discard a preloaded Cloudflare managed challenge response`() {
+        val mockRequest = mockWebRequest(
+            Uri.parse("https://checkout-sdk.myshopify.com"),
+            forMainFrame = true,
+        )
+        val mockResponse = mockWebResourceResponse(
+            status = HttpURLConnection.HTTP_FORBIDDEN,
+            description = "Forbidden",
+            headers = mutableMapOf("Cf-Mitigated" to " Challenge "),
+        )
+
+        val view = viewWithProcessor(activity)
+        view.isPreload = true
+        CheckoutWebView.cacheEntry = view.toCacheEntry(mockRequest.url.toString())
+
+        view.CheckoutWebViewClient().onReceivedHttpError(view, mockRequest, mockResponse)
+        ShadowLooper.shadowMainLooper().runToEndOfTasks()
+
+        verify(checkoutWebViewEventProcessor, never()).onCheckoutViewFailedWithError(any())
+        assertThat(CheckoutWebView.cacheEntry).isNull()
     }
 
     @Test

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
@@ -43,6 +43,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper
 import java.net.HttpURLConnection
@@ -192,6 +193,7 @@ class CheckoutWebViewClientTest {
         val view = viewWithProcessor(activity)
         view.isPreload = true
         view.notifyPresented()
+        shadowOf(view).callOnAttachedToWindow()
         CheckoutWebView.cacheEntry = view.toCacheEntry(mockRequest.url.toString())
 
         view.CheckoutWebViewClient().onReceivedHttpError(view, mockRequest, mockResponse)
@@ -215,6 +217,32 @@ class CheckoutWebViewClientTest {
 
         val view = viewWithProcessor(activity)
         view.isPreload = true
+        CheckoutWebView.cacheEntry = view.toCacheEntry(mockRequest.url.toString())
+
+        view.CheckoutWebViewClient().onReceivedHttpError(view, mockRequest, mockResponse)
+        ShadowLooper.shadowMainLooper().runToEndOfTasks()
+
+        verify(checkoutWebViewEventProcessor, never()).onCheckoutViewFailedWithError(any())
+        assertThat(CheckoutWebView.cacheEntry).isNull()
+    }
+
+    @Test
+    fun `should discard a previously presented preload after detachment`() {
+        val mockRequest = mockWebRequest(
+            Uri.parse("https://checkout-sdk.myshopify.com"),
+            forMainFrame = true,
+        )
+        val mockResponse = mockWebResourceResponse(
+            status = HttpURLConnection.HTTP_FORBIDDEN,
+            description = "Forbidden",
+            headers = mutableMapOf("Cf-Mitigated" to " Challenge "),
+        )
+
+        val view = viewWithProcessor(activity)
+        view.isPreload = true
+        view.notifyPresented()
+        shadowOf(view).callOnAttachedToWindow()
+        shadowOf(view).callOnDetachedFromWindow()
         CheckoutWebView.cacheEntry = view.toCacheEntry(mockRequest.url.toString())
 
         view.CheckoutWebViewClient().onReceivedHttpError(view, mockRequest, mockResponse)


### PR DESCRIPTION
## Summary

- Detect checkout responses carrying the Cloudflare cf-mitigated: challenge marker.
- Allow the challenge page to render when checkout has been presented instead of converting its 4xx response into a terminal checkout error.
- Stop, mark stale, and discard hidden challenge preloads so challenge content cannot remain cached for later presentation.
- Preserve existing handling for ordinary 4xx responses.
- Bump the Android SDK to 3.6.2 for the coordinated React Native 3.8.4 release.