### PR TITLE
fix: 429 is a non-recoverable error

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ your project:
 ### Gradle
 
 ```groovy
-implementation "com.shopify:checkout-sheet-kit:3.6.2"
+implementation "com.shopify:checkout-sheet-kit:3.6.3"
 ```
 
 ### Maven
@@ -65,7 +65,7 @@ implementation "com.shopify:checkout-sheet-kit:3.6.2"
 <dependency>
    <groupId>com.shopify</groupId>
    <artifactId>checkout-sheet-kit</artifactId>
-   <version>3.6.2</version>
+   <version>3.6.3</version>
 </dependency>
 ```
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -16,7 +16,7 @@ def resolveEnvVarValue(name, defaultValue) {
     return rawValue ? rawValue : defaultValue
 }
 
-def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.6.2")
+def versionName = resolveEnvVarValue("CHECKOUT_SHEET_KIT_VERSION", "3.6.3")
 
 ext {
     app_compat_version = '1.7.1'

--- a/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
+++ b/lib/src/main/java/com/shopify/checkoutsheetkit/BaseWebView.kt
@@ -198,7 +198,6 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
 
         internal open fun isRecoverable(statusCode: Int): Boolean {
             return when (statusCode) {
-                TOO_MANY_REQUESTS -> recoverErrors
                 ERROR_BAD_URL -> false
                 in CLIENT_ERROR -> false
                 else -> recoverErrors
@@ -247,7 +246,6 @@ internal abstract class BaseWebView(context: Context, attributeSet: AttributeSet
         private const val LOG_TAG = "BaseWebView"
         private const val CLOUDFLARE_MITIGATED_HEADER = "cf-mitigated"
         private const val CLOUDFLARE_CHALLENGE_VALUE = "challenge"
-        private const val TOO_MANY_REQUESTS = 429
         private val CLIENT_ERROR = 400..499
 
         private fun WebResourceResponse.isCloudflareManagedChallenge(): Boolean =

--- a/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
+++ b/lib/src/test/java/com/shopify/checkoutsheetkit/CheckoutWebViewClientTest.kt
@@ -253,6 +253,26 @@ class CheckoutWebViewClientTest {
     }
 
     @Test
+    fun `should call event processor with non-recoverable error for main frame - 429`() {
+        val mockRequest = mockWebRequest(Uri.parse("https://checkout-sdk.myshopify.com"), true)
+        val mockResponse = mockWebResourceResponse(
+            status = 429,
+            description = "Too Many Requests",
+        )
+
+        triggerOnReceivedHttpError(mockRequest, mockResponse)
+
+        val captor = argumentCaptor<CheckoutException>()
+        verify(checkoutWebViewEventProcessor).onCheckoutViewFailedWithError(captor.capture())
+        assertThat(captor.firstValue)
+            .isInstanceOf(HttpException::class.java)
+            .hasErrorCode(CheckoutUnavailableException.HTTP_ERROR)
+            .isNotRecoverable()
+            .hasDescription("Too Many Requests")
+            .hasStatusCode(429)
+    }
+
+    @Test
     fun `should call event processor calls onCheckoutViewFailedWithError on http error for main frame - 500`() {
         val mockRequest = mockWebRequest(Uri.parse("https://checkout-sdk.myshopify.com"), true)
         val mockResponse = mockWebResourceResponse(


### PR DESCRIPTION
### What changes are you making?


`429` should not be recoverable, Swift codifies this already, Android diverges behaviour

The change was simple but might read look initially like a fallthrough bug
This will not fall through to the `else` case as the `CLIENT_ERROR` is a range `private val CLIENT_ERROR = 400..499`

```diff
   internal open fun isRecoverable(statusCode: Int): Boolean {
            return when (statusCode) {
-                TOO_MANY_REQUESTS -> recoverErrors
                ERROR_BAD_URL -> false
                in CLIENT_ERROR -> false
                else -> recoverErrors
            }
        }
```
---

### Before you merge

> [!IMPORTANT]
>
> - [ ] I've added tests to support my implementation
> - [ ] I have read and agree with the [Contribution Guidelines](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md).
> - [ ] I have read and agree with the [Code of Conduct](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CODE_OF_CONDUCT.md).
> - [ ] I've updated the [README](https://github.com/shopify/checkout-sheet-kit-android).

---

<details>
<summary>Checklist for releasing a new version</summary>

- [ ] I have bumped the version number in the [`build.gradle` file](https://github.com/Shopify/checkout-kit-android/blob/main/lib/build.gradle#L17)
- [ ] I have updated the versions in the [README.md](https://github.com/shopify/checkout-sheet-kit-android/blob/main/README.md) for both Gradle and Maven.

</details>

> [!TIP]
> See the [Contributing documentation](https://github.com/shopify/checkout-sheet-kit-android/blob/main/.github/CONTRIBUTING.md#releasing-a-new-version) for instructions on how to publish a new version of the library.
